### PR TITLE
Fix incorrect active link detection (in nested route) in useVariantBasedOnRoute hook.

### DIFF
--- a/src/hooks/useVariantBasedOnRoute.ts
+++ b/src/hooks/useVariantBasedOnRoute.ts
@@ -2,18 +2,8 @@ import { usePathname } from "next/navigation"
 
 const useVariantBasedOnRoute = (): ((route: string) => "default" | "ghost") => {
   const pathname = usePathname()
-
   return (route: string) => {
-    // Get the last segment of the current pathname
-    const pathSegments = pathname.split("/").filter(Boolean)
-    const lastSegment = pathSegments[pathSegments.length - 1]
-
-    // Get the last segment of the route being passed
-    const routeSegments = route.split("/").filter(Boolean)
-    const lastRouteSegment = routeSegments[routeSegments.length - 1]
-
-    // Compare the last segment of the pathname with the last segment of the route
-    return lastSegment === lastRouteSegment ? "default" : "ghost"
+    return pathname === route ? "default" : "ghost"
   }
 }
 


### PR DESCRIPTION
The **useVariantBasedOnRoute** hook was incorrectly determining the active link **_(in nested route)_** by comparing the last segment of the current pathname with the last segment of the route being passed. 

This was causing the different link to be incorrectly highlighted  as active even when the user was not on that page.

**Changes**:

- Modified the useVariantBasedOnRoute hook to compare the entire pathname with the route being passed
- Updated the logic to correctly determine the active link