### PR TITLE
feat: Update dashboard layout controls and layout utils with sticky header upon scroll

### DIFF
--- a/src/app/(main)/dashboard/_components/sidebar/layout-controls.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/layout-controls.tsx
@@ -7,21 +7,22 @@ import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { updateContentLayout } from "@/lib/layout-utils";
+import { updateContentLayout, updateNavbarBehavior } from "@/lib/layout-utils";
 import { updateThemeMode, updateThemePreset } from "@/lib/theme-utils";
 import { setValueToCookie } from "@/server/server-actions";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
-import type { SidebarVariant, SidebarCollapsible, ContentLayout } from "@/types/preferences/layout";
+import type { SidebarVariant, SidebarCollapsible, ContentLayout, NavbarBehavior } from "@/types/preferences/layout";
 import { THEME_PRESET_OPTIONS, type ThemePreset, type ThemeMode } from "@/types/preferences/theme";
 
 type LayoutControlsProps = {
   readonly variant: SidebarVariant;
   readonly collapsible: SidebarCollapsible;
   readonly contentLayout: ContentLayout;
+  readonly navbarBehavior: NavbarBehavior;
 };
 
 export function LayoutControls(props: LayoutControlsProps) {
-  const { variant, collapsible, contentLayout } = props;
+  const { variant, collapsible, contentLayout, navbarBehavior } = props;
 
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const setThemeMode = usePreferencesStore((s) => s.setThemeMode);
@@ -41,6 +42,10 @@ export function LayoutControls(props: LayoutControlsProps) {
 
     if (key === "content_layout") {
       updateContentLayout(value);
+    }
+
+    if (key === "navbar_behavior") {
+      updateNavbarBehavior(value);
     }
     await setValueToCookie(key, value);
   };
@@ -156,6 +161,25 @@ export function LayoutControls(props: LayoutControlsProps) {
                 </ToggleGroupItem>
                 <ToggleGroupItem className="text-xs" value="full-width" aria-label="Toggle full-width">
                   Full Width
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            <div className="space-y-1">
+              <Label className="text-xs font-medium">Navbar Behavior</Label>
+              <ToggleGroup
+                className="w-full"
+                size="sm"
+                variant="outline"
+                type="single"
+                value={navbarBehavior}
+                onValueChange={(value) => handleValueChange("navbar_behavior", value)}
+              >
+                <ToggleGroupItem className="text-xs" value="sticky" aria-label="Toggle sticky">
+                  Sticky
+                </ToggleGroupItem>
+                <ToggleGroupItem className="text-xs" value="offcanvas" aria-label="Toggle offcanvas">
+                  Offcanvas
                 </ToggleGroupItem>
               </ToggleGroup>
             </div>

--- a/src/app/(main)/dashboard/_components/sidebar/layout-controls.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/layout-controls.tsx
@@ -7,22 +7,22 @@ import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { updateContentLayout, updateNavbarBehavior } from "@/lib/layout-utils";
+import { updateContentLayout, updateNavbarStyle } from "@/lib/layout-utils";
 import { updateThemeMode, updateThemePreset } from "@/lib/theme-utils";
 import { setValueToCookie } from "@/server/server-actions";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
-import type { SidebarVariant, SidebarCollapsible, ContentLayout, NavbarBehavior } from "@/types/preferences/layout";
+import type { SidebarVariant, SidebarCollapsible, ContentLayout, NavbarStyle } from "@/types/preferences/layout";
 import { THEME_PRESET_OPTIONS, type ThemePreset, type ThemeMode } from "@/types/preferences/theme";
 
 type LayoutControlsProps = {
   readonly variant: SidebarVariant;
   readonly collapsible: SidebarCollapsible;
   readonly contentLayout: ContentLayout;
-  readonly navbarBehavior: NavbarBehavior;
+  readonly navbarStyle: NavbarStyle;
 };
 
 export function LayoutControls(props: LayoutControlsProps) {
-  const { variant, collapsible, contentLayout, navbarBehavior } = props;
+  const { variant, collapsible, contentLayout, navbarStyle } = props;
 
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const setThemeMode = usePreferencesStore((s) => s.setThemeMode);
@@ -44,8 +44,8 @@ export function LayoutControls(props: LayoutControlsProps) {
       updateContentLayout(value);
     }
 
-    if (key === "navbar_behavior") {
-      updateNavbarBehavior(value);
+    if (key === "navbar_style") {
+      updateNavbarStyle(value);
     }
     await setValueToCookie(key, value);
   };
@@ -128,6 +128,25 @@ export function LayoutControls(props: LayoutControlsProps) {
             </div>
 
             <div className="space-y-1">
+              <Label className="text-xs font-medium">Navbar Style</Label>
+              <ToggleGroup
+                className="w-full"
+                size="sm"
+                variant="outline"
+                type="single"
+                value={navbarStyle}
+                onValueChange={(value) => handleValueChange("navbar_style", value)}
+              >
+                <ToggleGroupItem className="text-xs" value="sticky" aria-label="Toggle sticky">
+                  Sticky
+                </ToggleGroupItem>
+                <ToggleGroupItem className="text-xs" value="scroll" aria-label="Toggle scroll">
+                  Scroll
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            <div className="space-y-1">
               <Label className="text-xs font-medium">Sidebar Collapsible</Label>
               <ToggleGroup
                 className="w-full"
@@ -161,25 +180,6 @@ export function LayoutControls(props: LayoutControlsProps) {
                 </ToggleGroupItem>
                 <ToggleGroupItem className="text-xs" value="full-width" aria-label="Toggle full-width">
                   Full Width
-                </ToggleGroupItem>
-              </ToggleGroup>
-            </div>
-
-            <div className="space-y-1">
-              <Label className="text-xs font-medium">Navbar Behavior</Label>
-              <ToggleGroup
-                className="w-full"
-                size="sm"
-                variant="outline"
-                type="single"
-                value={navbarBehavior}
-                onValueChange={(value) => handleValueChange("navbar_behavior", value)}
-              >
-                <ToggleGroupItem className="text-xs" value="sticky" aria-label="Toggle sticky">
-                  Sticky
-                </ToggleGroupItem>
-                <ToggleGroupItem className="text-xs" value="offcanvas" aria-label="Toggle offcanvas">
-                  Offcanvas
                 </ToggleGroupItem>
               </ToggleGroup>
             </div>

--- a/src/app/(main)/dashboard/layout.tsx
+++ b/src/app/(main)/dashboard/layout.tsx
@@ -12,9 +12,11 @@ import {
   SIDEBAR_VARIANT_VALUES,
   SIDEBAR_COLLAPSIBLE_VALUES,
   CONTENT_LAYOUT_VALUES,
+  NAVBAR_BEHAVIOR_VALUES,
   type SidebarVariant,
   type SidebarCollapsible,
   type ContentLayout,
+  type NavbarBehavior,
 } from "@/types/preferences/layout";
 
 import { AccountSwitcher } from "./_components/sidebar/account-switcher";
@@ -26,16 +28,18 @@ export default async function Layout({ children }: Readonly<{ children: ReactNod
   const cookieStore = await cookies();
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
 
-  const [sidebarVariant, sidebarCollapsible, contentLayout] = await Promise.all([
+  const [sidebarVariant, sidebarCollapsible, contentLayout, navbarBehavior] = await Promise.all([
     getPreference<SidebarVariant>("sidebar_variant", SIDEBAR_VARIANT_VALUES, "inset"),
     getPreference<SidebarCollapsible>("sidebar_collapsible", SIDEBAR_COLLAPSIBLE_VALUES, "icon"),
     getPreference<ContentLayout>("content_layout", CONTENT_LAYOUT_VALUES, "centered"),
+    getPreference<NavbarBehavior>("navbar_behavior", NAVBAR_BEHAVIOR_VALUES, "offcanvas"),
   ]);
 
   const layoutPreferences = {
     contentLayout,
     variant: sidebarVariant,
     collapsible: sidebarCollapsible,
+    navbarBehavior,
   };
 
   return (
@@ -50,7 +54,12 @@ export default async function Layout({ children }: Readonly<{ children: ReactNod
           "max-[113rem]:peer-data-[variant=inset]:!mr-2 min-[101rem]:peer-data-[variant=inset]:peer-data-[state=collapsed]:!mr-auto",
         )}
       >
-        <header className="flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+        <header
+          className={cn(
+            "flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12",
+            navbarBehavior === "sticky" && "bg-background/80 border-b-border/50 sticky top-0 z-50 backdrop-blur-md",
+          )}
+        >
           <div className="flex w-full items-center justify-between px-4 lg:px-6">
             <div className="flex items-center gap-1 lg:gap-2">
               <SidebarTrigger className="-ml-1" />

--- a/src/app/(main)/dashboard/layout.tsx
+++ b/src/app/(main)/dashboard/layout.tsx
@@ -12,11 +12,11 @@ import {
   SIDEBAR_VARIANT_VALUES,
   SIDEBAR_COLLAPSIBLE_VALUES,
   CONTENT_LAYOUT_VALUES,
-  NAVBAR_BEHAVIOR_VALUES,
+  NAVBAR_STYLE_VALUES,
   type SidebarVariant,
   type SidebarCollapsible,
   type ContentLayout,
-  type NavbarBehavior,
+  type NavbarStyle,
 } from "@/types/preferences/layout";
 
 import { AccountSwitcher } from "./_components/sidebar/account-switcher";
@@ -28,18 +28,18 @@ export default async function Layout({ children }: Readonly<{ children: ReactNod
   const cookieStore = await cookies();
   const defaultOpen = cookieStore.get("sidebar_state")?.value === "true";
 
-  const [sidebarVariant, sidebarCollapsible, contentLayout, navbarBehavior] = await Promise.all([
+  const [sidebarVariant, sidebarCollapsible, contentLayout, navbarStyle] = await Promise.all([
     getPreference<SidebarVariant>("sidebar_variant", SIDEBAR_VARIANT_VALUES, "inset"),
     getPreference<SidebarCollapsible>("sidebar_collapsible", SIDEBAR_COLLAPSIBLE_VALUES, "icon"),
     getPreference<ContentLayout>("content_layout", CONTENT_LAYOUT_VALUES, "centered"),
-    getPreference<NavbarBehavior>("navbar_behavior", NAVBAR_BEHAVIOR_VALUES, "offcanvas"),
+    getPreference<NavbarStyle>("navbar_style", NAVBAR_STYLE_VALUES, "sticky"),
   ]);
 
   const layoutPreferences = {
     contentLayout,
     variant: sidebarVariant,
     collapsible: sidebarCollapsible,
-    navbarBehavior,
+    navbarStyle,
   };
 
   return (
@@ -55,9 +55,16 @@ export default async function Layout({ children }: Readonly<{ children: ReactNod
         )}
       >
         <header
+          data-navbar-style={navbarStyle}
+          data-sidebar-variant={sidebarVariant}
           className={cn(
             "flex h-12 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12",
-            navbarBehavior === "sticky" && "bg-background/80 border-b-border/50 sticky top-0 z-50 backdrop-blur-md",
+            // Navbar style classes
+            "data-[navbar-style=sticky]:bg-background/80 data-[navbar-style=sticky]:border-b-border/50 data-[navbar-style=sticky]:sticky data-[navbar-style=sticky]:top-0 data-[navbar-style=sticky]:z-50 data-[navbar-style=sticky]:backdrop-blur-md",
+            // Sidebar variant specific adjustments
+            "data-[sidebar-variant=floating]:border-l-0 data-[sidebar-variant=inset]:border-l-0 data-[sidebar-variant=sidebar]:border-l-0",
+            // Ensure consistent positioning across all variants
+            "relative",
           )}
         >
           <div className="flex w-full items-center justify-between px-4 lg:px-6">

--- a/src/lib/layout-utils.ts
+++ b/src/lib/layout-utils.ts
@@ -4,3 +4,14 @@ export function updateContentLayout(value: "centered" | "full-width") {
     target.setAttribute("data-content-layout", value);
   }
 }
+
+export function updateNavbarBehavior(value: "sticky" | "offcanvas") {
+  const target = document.querySelector("header");
+  if (target) {
+    if (value === "sticky") {
+      target.classList.add("sticky", "top-0", "z-50", "backdrop-blur-md", "bg-background/80", "border-b-border/50");
+    } else {
+      target.classList.remove("sticky", "top-0", "z-50", "backdrop-blur-md", "bg-background/80", "border-b-border/50");
+    }
+  }
+}

--- a/src/lib/layout-utils.ts
+++ b/src/lib/layout-utils.ts
@@ -5,13 +5,9 @@ export function updateContentLayout(value: "centered" | "full-width") {
   }
 }
 
-export function updateNavbarBehavior(value: "sticky" | "offcanvas") {
-  const target = document.querySelector("header");
+export function updateNavbarStyle(value: "sticky" | "scroll") {
+  const target = document.querySelector("header[data-navbar-style]");
   if (target) {
-    if (value === "sticky") {
-      target.classList.add("sticky", "top-0", "z-50", "backdrop-blur-md", "bg-background/80", "border-b-border/50");
-    } else {
-      target.classList.remove("sticky", "top-0", "z-50", "backdrop-blur-md", "bg-background/80", "border-b-border/50");
-    }
+    target.setAttribute("data-navbar-style", value);
   }
 }

--- a/src/types/preferences/layout.ts
+++ b/src/types/preferences/layout.ts
@@ -23,10 +23,10 @@ export const CONTENT_LAYOUT_OPTIONS = [
 export const CONTENT_LAYOUT_VALUES = CONTENT_LAYOUT_OPTIONS.map((v) => v.value);
 export type ContentLayout = (typeof CONTENT_LAYOUT_VALUES)[number];
 
-// Navbar Behavior
-export const NAVBAR_BEHAVIOR_OPTIONS = [
+// Navbar Style
+export const NAVBAR_STYLE_OPTIONS = [
   { label: "Sticky", value: "sticky" },
-  { label: "Offcanvas", value: "offcanvas" },
+  { label: "Scroll", value: "scroll" },
 ] as const;
-export const NAVBAR_BEHAVIOR_VALUES = NAVBAR_BEHAVIOR_OPTIONS.map((v) => v.value);
-export type NavbarBehavior = (typeof NAVBAR_BEHAVIOR_VALUES)[number];
+export const NAVBAR_STYLE_VALUES = NAVBAR_STYLE_OPTIONS.map((v) => v.value);
+export type NavbarStyle = (typeof NAVBAR_STYLE_VALUES)[number];

--- a/src/types/preferences/layout.ts
+++ b/src/types/preferences/layout.ts
@@ -22,3 +22,11 @@ export const CONTENT_LAYOUT_OPTIONS = [
 ] as const;
 export const CONTENT_LAYOUT_VALUES = CONTENT_LAYOUT_OPTIONS.map((v) => v.value);
 export type ContentLayout = (typeof CONTENT_LAYOUT_VALUES)[number];
+
+// Navbar Behavior
+export const NAVBAR_BEHAVIOR_OPTIONS = [
+  { label: "Sticky", value: "sticky" },
+  { label: "Offcanvas", value: "offcanvas" },
+] as const;
+export const NAVBAR_BEHAVIOR_VALUES = NAVBAR_BEHAVIOR_OPTIONS.map((v) => v.value);
+export type NavbarBehavior = (typeof NAVBAR_BEHAVIOR_VALUES)[number];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Navbar Style setting in Dashboard Layout Controls with two options: Sticky and Scroll.
  * Sticky keeps the header visible with enhanced styling; Scroll returns to normal scrolling behavior.
  * The preference is saved and applied across the dashboard and reflected in the header UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->