### PR TITLE
.1998255244458903:077b1dc518a90da2040ba1d14cc0e115_69e1e6ce4b8f28891982dbb1.69e1e8e04b8f28891982dbe0.69e1e8e0f0145f1b1d4a6962:Trae CN.T(2026/4/17 16:01:36)

### DIFF
--- a/src/app/(main)/dashboard/crm/_components/activity-timeline.tsx
+++ b/src/app/(main)/dashboard/crm/_components/activity-timeline.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import type * as React from "react";
+
+import { format, formatDistanceToNow } from "date-fns";
+import {
+  Calendar,
+  CheckCircle,
+  Clock,
+  DollarSign,
+  Mail,
+  MessageSquare,
+  MoreHorizontal,
+  Phone,
+  Plus,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn, formatCurrency } from "@/lib/utils";
+
+const activityData = [
+  {
+    id: 1,
+    type: "deal-won",
+    title: "Deal closed with Vercel",
+    description: "Successfully closed the $85K MVP development deal",
+    amount: 85000,
+    user: {
+      name: "Guillermo Rauch",
+      avatar: "https://avatars.githubusercontent.com/u/12345",
+      initials: "GR",
+    },
+    time: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    status: "success",
+    priority: "high",
+  },
+  {
+    id: 2,
+    type: "meeting-scheduled",
+    title: "Demo call scheduled with OpenAI",
+    description: "Product demo for the enterprise plan",
+    user: {
+      name: "Sam Altman",
+      avatar: "https://avatars.githubusercontent.com/u/12346",
+      initials: "SA",
+    },
+    time: new Date(Date.now() - 4 * 60 * 60 * 1000),
+    status: "upcoming",
+    scheduledTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    priority: "high",
+  },
+  {
+    id: 3,
+    type: "email-sent",
+    title: "Proposal sent to Shadcn",
+    description: "Custom UI kit development proposal - $45K",
+    amount: 45000,
+    user: {
+      name: "Shadcn",
+      avatar: "https://avatars.githubusercontent.com/u/12347",
+      initials: "SH",
+    },
+    time: new Date(Date.now() - 6 * 60 * 60 * 1000),
+    status: "pending",
+    priority: "medium",
+  },
+  {
+    id: 4,
+    type: "lead-qualified",
+    title: "Lead qualified: Astro team",
+    description: "Moved from New to Qualified stage",
+    user: {
+      name: "Fred K. Schott",
+      avatar: "https://avatars.githubusercontent.com/u/12348",
+      initials: "FS",
+    },
+    time: new Date(Date.now() - 12 * 60 * 60 * 1000),
+    status: "success",
+    priority: "medium",
+  },
+  {
+    id: 5,
+    type: "follow-up",
+    title: "Follow-up required: Cal.com",
+    description: "Stalled for 14 days - needs urgent attention",
+    user: {
+      name: "Peer Richelsen",
+      avatar: "https://avatars.githubusercontent.com/u/12349",
+      initials: "PR",
+    },
+    time: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    status: "at-risk",
+    priority: "high",
+  },
+  {
+    id: 6,
+    type: "payment-received",
+    title: "Payment received from Medusa",
+    description: "First installment of $12.5K received",
+    amount: 12500,
+    user: {
+      name: "Sebastian Rindom",
+      avatar: "https://avatars.githubusercontent.com/u/12350",
+      initials: "SR",
+    },
+    time: new Date(Date.now() - 36 * 60 * 60 * 1000),
+    status: "success",
+    priority: "low",
+  },
+  {
+    id: 7,
+    type: "call-completed",
+    title: "Discovery call with Mail0",
+    description: "Great conversation, scheduled follow-up demo",
+    user: {
+      name: "Nizzy",
+      avatar: "https://avatars.githubusercontent.com/u/12351",
+      initials: "NZ",
+    },
+    time: new Date(Date.now() - 48 * 60 * 60 * 1000),
+    status: "success",
+    priority: "medium",
+  },
+];
+
+const upcomingTasks = [
+  {
+    id: 1,
+    title: "Demo with OpenAI",
+    description: "Enterprise product demo",
+    dueDate: new Date(Date.now() + 4 * 60 * 60 * 1000),
+    priority: "high",
+    type: "meeting",
+  },
+  {
+    id: 2,
+    title: "Follow up on Astro deal",
+    description: "Send revised proposal",
+    dueDate: new Date(Date.now() + 8 * 60 * 60 * 1000),
+    priority: "medium",
+    type: "email",
+  },
+  {
+    id: 3,
+    title: "QBR with Vercel",
+    description: "Quarterly business review",
+    dueDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    priority: "high",
+    type: "meeting",
+  },
+  {
+    id: 4,
+    title: "Update CRM records",
+    description: "Clean up stalled deals",
+    dueDate: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    priority: "low",
+    type: "task",
+  },
+];
+
+const typeIcons: Record<string, React.ReactNode> = {
+  "deal-won": <DollarSign className="size-4" />,
+  "meeting-scheduled": <Calendar className="size-4" />,
+  "email-sent": <Mail className="size-4" />,
+  "lead-qualified": <Users className="size-4" />,
+  "follow-up": <Clock className="size-4" />,
+  "payment-received": <DollarSign className="size-4" />,
+  "call-completed": <Phone className="size-4" />,
+};
+
+const statusColors: Record<string, string> = {
+  success: "bg-green-500/10 text-green-500",
+  pending: "bg-blue-500/10 text-blue-500",
+  upcoming: "bg-primary/10 text-primary",
+  "at-risk": "bg-destructive/10 text-destructive",
+};
+
+const priorityBadges: Record<
+  string,
+  { variant: "default" | "secondary" | "destructive" | "outline" | "ghost" | "link"; label: string }
+> = {
+  high: { variant: "destructive", label: "High" },
+  medium: { variant: "secondary", label: "Medium" },
+  low: { variant: "outline", label: "Low" },
+};
+
+export function ActivityTimeline() {
+  return (
+    <Card className="shadow-xs">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Activity & Tasks</CardTitle>
+            <CardDescription>Track recent activities and upcoming tasks</CardDescription>
+          </div>
+          <Button size="sm">
+            <Plus className="mr-1.5 size-4" />
+            Add Task
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Tabs defaultValue="activity" className="w-full">
+          <TabsList className="mb-4 w-full grid-cols-2">
+            <TabsTrigger value="activity" className="flex-1">
+              <TrendingUp className="mr-1.5 size-4" />
+              Recent Activity
+            </TabsTrigger>
+            <TabsTrigger value="tasks" className="flex-1">
+              <CheckCircle className="mr-1.5 size-4" />
+              Upcoming Tasks
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="activity" className="mt-0">
+            <div className="relative">
+              {activityData.map((activity, index) => (
+                <div key={activity.id} className="flex gap-4">
+                  <div className="flex flex-col items-center">
+                    <div
+                      className={cn(
+                        "flex size-8 shrink-0 items-center justify-center rounded-full",
+                        statusColors[activity.status],
+                      )}
+                    >
+                      {typeIcons[activity.type]}
+                    </div>
+                    {index < activityData.length - 1 && <div className="mt-2 w-px flex-1 bg-border" />}
+                  </div>
+                  <div className="flex-1 pb-6">
+                    <div className="flex items-start justify-between">
+                      <div className="flex items-center gap-2">
+                        <h4 className="font-medium text-sm">{activity.title}</h4>
+                        <Badge variant={priorityBadges[activity.priority].variant} className="h-4 text-[10px]">
+                          {priorityBadges[activity.priority].label}
+                        </Badge>
+                      </div>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon-xs">
+                            <MoreHorizontal className="size-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-40">
+                          <DropdownMenuItem className="cursor-pointer">View Details</DropdownMenuItem>
+                          <DropdownMenuItem className="cursor-pointer">Add Note</DropdownMenuItem>
+                          <DropdownMenuItem className="cursor-pointer">Schedule Follow-up</DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                    <p className="text-muted-foreground mt-1 text-xs">{activity.description}</p>
+                    <div className="mt-2 flex items-center gap-3">
+                      <div className="flex items-center gap-2">
+                        <Avatar className="size-5">
+                          <AvatarImage src={activity.user.avatar} alt={activity.user.name} />
+                          <AvatarFallback className="text-[10px]">{activity.user.initials}</AvatarFallback>
+                        </Avatar>
+                        <span className="text-muted-foreground text-xs">{activity.user.name}</span>
+                      </div>
+                      <span className="text-muted-foreground text-xs">•</span>
+                      <span className="text-muted-foreground text-xs tabular-nums">
+                        {formatDistanceToNow(activity.time, { addSuffix: true })}
+                      </span>
+                      {activity.amount && (
+                        <>
+                          <span className="text-muted-foreground text-xs">•</span>
+                          <span className="font-medium text-xs text-green-500">
+                            {formatCurrency(activity.amount, { noDecimals: true })}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </TabsContent>
+          <TabsContent value="tasks" className="mt-0">
+            <div className="space-y-3">
+              {upcomingTasks.map((task) => (
+                <div
+                  key={task.id}
+                  className={cn(
+                    "flex items-start gap-3 rounded-lg border p-3 transition-all hover:bg-muted/50",
+                    task.priority === "high" && "border-destructive/30 bg-destructive/5",
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full",
+                      task.priority === "high"
+                        ? "bg-destructive/10 text-destructive"
+                        : task.priority === "medium"
+                          ? "bg-yellow-500/10 text-yellow-500"
+                          : "bg-green-500/10 text-green-500",
+                    )}
+                  >
+                    {task.type === "meeting" ? (
+                      <Calendar className="size-3" />
+                    ) : task.type === "email" ? (
+                      <Mail className="size-3" />
+                    ) : (
+                      <CheckCircle className="size-3" />
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between">
+                      <h4 className="font-medium text-sm truncate">{task.title}</h4>
+                      <Badge variant={priorityBadges[task.priority].variant} className="h-4 text-[10px] ml-2 shrink-0">
+                        {priorityBadges[task.priority].label}
+                      </Badge>
+                    </div>
+                    <p className="text-muted-foreground mt-0.5 text-xs">{task.description}</p>
+                    <div className="mt-2 flex items-center gap-2">
+                      <Clock className="size-3 text-muted-foreground" />
+                      <span className="text-muted-foreground text-xs tabular-nums">
+                        Due: {format(task.dueDate, "MMM d, h:mm a")}
+                      </span>
+                      <span className="text-muted-foreground text-xs">•</span>
+                      <span className="text-muted-foreground text-xs tabular-nums">
+                        {formatDistanceToNow(task.dueDate, { addSuffix: true })}
+                      </span>
+                    </div>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon-xs" className="shrink-0">
+                        <MoreHorizontal className="size-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-40">
+                      <DropdownMenuItem className="cursor-pointer">Mark Complete</DropdownMenuItem>
+                      <DropdownMenuItem className="cursor-pointer">Reschedule</DropdownMenuItem>
+                      <DropdownMenuItem className="cursor-pointer">Delegate</DropdownMenuItem>
+                      <DropdownMenuItem className="cursor-pointer text-destructive">Delete</DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              ))}
+            </div>
+            <Separator className="my-4" />
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                <CheckCircle className="size-3 text-green-500" />
+                <span>8 tasks completed this week</span>
+              </div>
+              <Button variant="ghost" size="sm" className="text-primary">
+                View All Tasks
+              </Button>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/crm/_components/page-header.tsx
+++ b/src/app/(main)/dashboard/crm/_components/page-header.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import * as React from "react";
+
+import { format, subDays } from "date-fns";
+import { Bell, Calendar, ChevronDown, Plus, Search, Settings, Users } from "lucide-react";
+import type { DateRange } from "react-day-picker";
+
+import { DateRangePicker } from "@/components/date-range-picker";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar as CalendarComponent } from "@/components/ui/calendar";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { rootUser } from "@/data/users";
+import { cn } from "@/lib/utils";
+
+const quickActions = [
+  { label: "New Lead", icon: Users, color: "text-primary" },
+  { label: "Send Email", icon: "email", color: "text-primary" },
+  { label: "Schedule Call", icon: Calendar, color: "text-primary" },
+  { label: "More Actions", icon: Settings, color: "text-muted-foreground" },
+];
+
+const timeRanges = [
+  { label: "Today", value: "today" },
+  { label: "Week", value: "week" },
+  { label: "Month", value: "month" },
+  { label: "Quarter", value: "quarter" },
+  { label: "Year", value: "year" },
+  { label: "Custom", value: "custom" },
+];
+
+export function PageHeader() {
+  const [activeTimeRange, setActiveTimeRange] = React.useState("month");
+  const [searchQuery, setSearchQuery] = React.useState("");
+
+  const getGreeting = () => {
+    const hour = new Date().getHours();
+    if (hour < 12) return "Good Morning";
+    if (hour < 18) return "Good Afternoon";
+    return "Good Evening";
+  };
+
+  return (
+    <Card className="shadow-xs border-0">
+      <CardContent className="p-0">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2 border-b px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-1">
+              <h1 className="font-semibold text-2xl tracking-tight">
+                {getGreeting()}, {rootUser.name} 👋
+              </h1>
+              <p className="text-muted-foreground text-sm">Here's what's happening with your sales pipeline today.</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="relative hidden sm:block">
+                <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
+                <Input
+                  type="search"
+                  placeholder="Search leads, contacts..."
+                  className="w-64 pl-8"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+              <Button variant="outline" size="icon">
+                <Bell className="size-4" />
+              </Button>
+              <Button size="icon">
+                <Plus className="size-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4 px-6 pb-4 pt-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <Tabs defaultValue="overview" className="hidden sm:block">
+                <TabsList>
+                  <TabsTrigger value="overview">Overview</TabsTrigger>
+                  <TabsTrigger value="analytics">Analytics</TabsTrigger>
+                  <TabsTrigger value="reports">Reports</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <TimeRangeSelector activeRange={activeTimeRange} onRangeChange={setActiveTimeRange} />
+              <QuickActions />
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TimeRangeSelector({
+  activeRange,
+  onRangeChange,
+}: {
+  activeRange: string;
+  onRangeChange: (value: string) => void;
+}) {
+  const [dateRange, setDateRange] = React.useState<DateRange | undefined>(() => {
+    const to = new Date();
+    const from = subDays(to, 29);
+    return { from, to };
+  });
+
+  const getRangeLabel = () => {
+    if (activeRange === "custom" && dateRange?.from && dateRange?.to) {
+      return `${format(dateRange.from, "d MMM")} - ${format(dateRange.to, "d MMM yyyy")}`;
+    }
+    return timeRanges.find((r) => r.value === activeRange)?.label || "Select Range";
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="gap-2">
+          <Calendar className="size-4" />
+          <span className="hidden sm:inline">{getRangeLabel()}</span>
+          <ChevronDown className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Time Range</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          {timeRanges.map((range) => (
+            <DropdownMenuItem
+              key={range.value}
+              onClick={() => {
+                if (range.value !== "custom") {
+                  onRangeChange(range.value);
+                }
+              }}
+              className={cn("cursor-pointer", activeRange === range.value && "bg-accent text-accent-foreground")}
+            >
+              {range.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <div className="p-2">
+          <p className="text-muted-foreground mb-2 text-xs">Custom Range</p>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className="w-full justify-start text-left font-normal" size="sm">
+                <Calendar className="mr-2 size-4" />
+                {dateRange?.from
+                  ? dateRange.to
+                    ? `${format(dateRange.from, "LLL dd, y")} - ${format(dateRange.to, "LLL dd, y")}`
+                    : format(dateRange.from, "LLL dd, y")
+                  : "Pick a date"}
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0" align="start">
+              <CalendarComponent
+                mode="range"
+                defaultMonth={dateRange?.from}
+                selected={dateRange}
+                onSelect={(value) => {
+                  setDateRange(value);
+                  if (value?.from && value?.to) {
+                    onRangeChange("custom");
+                  }
+                }}
+                numberOfMonths={2}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function QuickActions() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>
+          <Plus className="size-4" />
+          <span className="hidden sm:inline">Quick Actions</span>
+          <ChevronDown className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Quick Actions</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuItem className="cursor-pointer">
+            <Users className="mr-2 size-4" />
+            <span>Add New Lead</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="cursor-pointer">
+            <Calendar className="mr-2 size-4" />
+            <span>Schedule Meeting</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="cursor-pointer">
+            <Badge className="mr-2 size-4" />
+            <span>Create Proposal</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="cursor-pointer">
+            <Search className="mr-2 size-4" />
+            <span>Export Reports</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuGroup>
+          <DropdownMenuLabel>Quick Filters</DropdownMenuLabel>
+          <DropdownMenuItem className="cursor-pointer">
+            <span>Hot Leads</span>
+            <Badge variant="destructive" className="ml-auto">
+              12
+            </Badge>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="cursor-pointer">
+            <span>Stalled Deals</span>
+            <Badge variant="secondary" className="ml-auto">
+              8
+            </Badge>
+          </DropdownMenuItem>
+          <DropdownMenuItem className="cursor-pointer">
+            <span>Due Today</span>
+            <Badge variant="outline" className="ml-auto">
+              5
+            </Badge>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/app/(main)/dashboard/crm/_components/recent-leads-table/columns.tsx
+++ b/src/app/(main)/dashboard/crm/_components/recent-leads-table/columns.tsx
@@ -2,7 +2,17 @@
 "use no memo";
 
 import type { ColumnDef } from "@tanstack/react-table";
-import { EllipsisVertical } from "lucide-react";
+import {
+  ChevronRight,
+  Clock,
+  EllipsisVertical,
+  Mail,
+  MessageSquare,
+  Phone,
+  TrendingDown,
+  TrendingUp,
+  Users,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,11 +22,46 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 import type { RecentLeadRow } from "./schema";
+
+const statusConfig: Record<
+  string,
+  {
+    variant: "default" | "secondary" | "destructive" | "outline" | "ghost" | "link";
+    label: string;
+    color: string;
+  }
+> = {
+  New: { variant: "outline", label: "New", color: "text-muted-foreground" },
+  Contacted: { variant: "secondary", label: "Contacted", color: "text-blue-500" },
+  Qualified: { variant: "default", label: "Qualified", color: "text-primary" },
+  "Proposal Sent": { variant: "secondary", label: "Proposal", color: "text-purple-500" },
+  Negotiation: { variant: "outline", label: "Negotiation", color: "text-orange-500" },
+  Won: { variant: "default", label: "Won", color: "text-green-500" },
+  Lost: { variant: "destructive", label: "Lost", color: "text-destructive" },
+};
+
+const sourceConfig: Record<string, { icon: React.ReactNode; color: string }> = {
+  Website: { icon: <Users className="size-3" />, color: "text-primary" },
+  Referral: { icon: <Users className="size-3" />, color: "text-green-500" },
+  "Social Media": { icon: <MessageSquare className="size-3" />, color: "text-blue-500" },
+  "Cold Outreach": { icon: <Mail className="size-3" />, color: "text-orange-500" },
+  Other: { icon: <EllipsisVertical className="size-3" />, color: "text-muted-foreground" },
+};
+
+const getInitials = (name: string) => {
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase();
+};
 
 export const recentLeadsColumns: ColumnDef<RecentLeadRow>[] = [
   {
@@ -44,57 +89,179 @@ export const recentLeadsColumns: ColumnDef<RecentLeadRow>[] = [
   {
     accessorKey: "id",
     header: "Ref",
-    cell: ({ row }) => <span className="tabular-nums">{row.original.id}</span>,
+    cell: ({ row }) => <span className="font-mono text-muted-foreground text-xs tabular-nums">{row.original.id}</span>,
     enableHiding: false,
   },
   {
     accessorKey: "name",
-    header: "Name",
-    cell: ({ row }) => row.original.name,
+    header: "Lead",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3">
+        <div className="relative">
+          <div className="flex size-8 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-medium">
+            {getInitials(row.original.name)}
+          </div>
+          <div
+            className={cn(
+              "absolute -bottom-0.5 -right-0.5 size-2.5 rounded-full border-2 border-background",
+              row.original.status === "Won"
+                ? "bg-green-500"
+                : row.original.status === "Lost"
+                  ? "bg-destructive"
+                  : row.original.status === "Negotiation"
+                    ? "bg-orange-500"
+                    : "bg-primary",
+            )}
+          />
+        </div>
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="font-medium text-sm truncate">{row.original.name}</p>
+          </div>
+          <p className="text-muted-foreground text-xs truncate">{row.original.company}</p>
+        </div>
+      </div>
+    ),
     enableHiding: false,
-  },
-  {
-    accessorKey: "company",
-    header: "Company",
-    cell: ({ row }) => row.original.company,
   },
   {
     accessorKey: "status",
     header: "Status",
-    cell: ({ row }) => <Badge variant="secondary">{row.original.status}</Badge>,
+    cell: ({ row }) => {
+      const status = row.original.status;
+      const config = statusConfig[status] || statusConfig.New;
+
+      return (
+        <Badge
+          variant={config.variant}
+          className={cn(
+            "h-5 text-[10px] font-medium",
+            status === "Won" && "bg-green-500/10 text-green-500 hover:bg-green-500/20",
+            status === "Qualified" && "bg-primary/10 text-primary hover:bg-primary/20",
+            status === "Negotiation" && "bg-orange-500/10 text-orange-500 hover:bg-orange-500/20",
+            status === "Lost" && "bg-destructive/10 text-destructive hover:bg-destructive/20",
+          )}
+        >
+          {config.label}
+        </Badge>
+      );
+    },
   },
   {
     accessorKey: "source",
     header: "Source",
-    cell: ({ row }) => <Badge variant="outline">{row.original.source}</Badge>,
+    cell: ({ row }) => {
+      const source = row.original.source;
+      const config = sourceConfig[source] || sourceConfig.Other;
+
+      return (
+        <div className="flex items-center gap-1.5">
+          <span className={cn("flex size-5 items-center justify-center rounded-full bg-muted", config.color)}>
+            {config.icon}
+          </span>
+          <span className="text-xs">{source}</span>
+        </div>
+      );
+    },
   },
   {
     accessorKey: "lastActivity",
-    header: "Last Activity",
-    cell: ({ row }) => <span className="text-muted-foreground tabular-nums">{row.original.lastActivity}</span>,
+    header: "Activity",
+    cell: ({ row }) => {
+      const activity = row.original.lastActivity;
+      const isUrgent = activity.includes("ago") && (activity.includes("d") || activity.includes("day"));
+      const isRecent = activity.includes("m") || activity.includes("h");
+
+      return (
+        <div className="flex items-center gap-1.5">
+          <Clock
+            className={cn(
+              "size-3.5",
+              isRecent ? "text-green-500" : isUrgent ? "text-destructive" : "text-muted-foreground",
+            )}
+          />
+          <span
+            className={cn(
+              "text-xs tabular-nums",
+              isRecent ? "text-green-500 font-medium" : isUrgent ? "text-destructive" : "text-muted-foreground",
+            )}
+          >
+            {activity}
+          </span>
+        </div>
+      );
+    },
   },
   {
     id: "actions",
-    cell: () => (
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="flex size-8 text-muted-foreground">
-            <EllipsisVertical />
-            <span className="sr-only">Open menu</span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-32">
-          <DropdownMenuGroup>
-            <DropdownMenuItem>View</DropdownMenuItem>
-            <DropdownMenuItem>Assign</DropdownMenuItem>
-            <DropdownMenuItem>Archive</DropdownMenuItem>
-          </DropdownMenuGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuGroup>
-            <DropdownMenuItem variant="destructive">Delete</DropdownMenuItem>
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+    cell: ({ row }) => (
+      <div className="flex items-center justify-end gap-1">
+        <Button variant="ghost" size="icon-xs" className="text-muted-foreground hover:text-primary">
+          <Phone className="size-3.5" />
+        </Button>
+        <Button variant="ghost" size="icon-xs" className="text-muted-foreground hover:text-primary">
+          <Mail className="size-3.5" />
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon-xs" className="text-muted-foreground">
+              <EllipsisVertical className="size-3.5" />
+              <span className="sr-only">Open menu</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuLabel className="text-muted-foreground text-xs">
+              {row.original.name} · {row.original.id}
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem className="cursor-pointer">
+                <Users className="mr-2 size-4" />
+                View Details
+              </DropdownMenuItem>
+              <DropdownMenuItem className="cursor-pointer">
+                <Phone className="mr-2 size-4" />
+                Schedule Call
+              </DropdownMenuItem>
+              <DropdownMenuItem className="cursor-pointer">
+                <Mail className="mr-2 size-4" />
+                Send Email
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-muted-foreground text-xs">Change Status</DropdownMenuLabel>
+            <DropdownMenuGroup>
+              <DropdownMenuItem className="cursor-pointer">
+                <ChevronRight className="mr-2 size-4" />
+                Mark as Contacted
+              </DropdownMenuItem>
+              <DropdownMenuItem className="cursor-pointer">
+                <TrendingUp className="mr-2 size-4 text-green-500" />
+                Qualify Lead
+              </DropdownMenuItem>
+              <DropdownMenuItem className="cursor-pointer">
+                <TrendingDown className="mr-2 size-4 text-destructive" />
+                Disqualify
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem className="cursor-pointer">
+                <Users className="mr-2 size-4" />
+                Assign to...
+              </DropdownMenuItem>
+              <DropdownMenuItem className="cursor-pointer">
+                <EllipsisVertical className="mr-2 size-4" />
+                Archive
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem variant="destructive" className="cursor-pointer">
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
     ),
     enableHiding: false,
   },

--- a/src/app/(main)/dashboard/crm/_components/status-overview.tsx
+++ b/src/app/(main)/dashboard/crm/_components/status-overview.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  AlertCircle,
+  ArrowDown,
+  ArrowUp,
+  CheckCircle,
+  Clock,
+  DollarSign,
+  TrendingDown,
+  TrendingUp,
+  Users,
+  XCircle,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { cn, formatCurrency } from "@/lib/utils";
+
+const statusMetrics = [
+  {
+    id: "active-leads",
+    title: "Active Leads",
+    value: "84",
+    change: "+12",
+    changeType: "positive" as const,
+    icon: Users,
+    color: "text-primary",
+    bgColor: "bg-primary/10",
+    progress: 72,
+    description: "Leads in active stages",
+  },
+  {
+    id: "at-risk",
+    title: "At Risk Deals",
+    value: "11",
+    change: "-3",
+    changeType: "negative" as const,
+    icon: AlertCircle,
+    color: "text-destructive",
+    bgColor: "bg-destructive/10",
+    progress: 15,
+    description: "Stalled > 14 days",
+  },
+  {
+    id: "closing-this-week",
+    title: "Closing This Week",
+    value: "7",
+    change: "+2",
+    changeType: "positive" as const,
+    icon: CheckCircle,
+    color: "text-green-500",
+    bgColor: "bg-green-500/10",
+    progress: 85,
+    description: "Expected to close",
+    valuePrefix: "$",
+    valueSuffix: "K",
+    numericValue: 245,
+  },
+  {
+    id: "missed-opportunities",
+    title: "Missed Opportunities",
+    value: "3",
+    change: "-1",
+    changeType: "positive" as const,
+    icon: XCircle,
+    color: "text-orange-500",
+    bgColor: "bg-orange-500/10",
+    progress: 5,
+    description: "Lost this period",
+  },
+];
+
+const pipelineStages = [
+  {
+    stage: "New Leads",
+    count: 32,
+    value: 480000,
+    status: "healthy" as const,
+    trend: "up" as const,
+    trendValue: "+8%",
+  },
+  {
+    stage: "Qualified",
+    count: 24,
+    value: 360000,
+    status: "healthy" as const,
+    trend: "up" as const,
+    trendValue: "+5%",
+  },
+  {
+    stage: "Proposal Sent",
+    count: 15,
+    value: 225000,
+    status: "warning" as const,
+    trend: "down" as const,
+    trendValue: "-3%",
+  },
+  {
+    stage: "Negotiation",
+    count: 8,
+    value: 120000,
+    status: "at-risk" as const,
+    trend: "down" as const,
+    trendValue: "-12%",
+  },
+  {
+    stage: "Closed Won",
+    count: 5,
+    value: 75000,
+    status: "healthy" as const,
+    trend: "up" as const,
+    trendValue: "+15%",
+  },
+];
+
+export function StatusOverview() {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+      <div className="space-y-4 lg:col-span-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {statusMetrics.map((metric) => (
+            <StatusCard key={metric.id} metric={metric} />
+          ))}
+        </div>
+        <PipelineHealthCard />
+      </div>
+      <div className="space-y-4">
+        <QuickStatsCard />
+        <ActivitySummaryCard />
+      </div>
+    </div>
+  );
+}
+
+function StatusCard({ metric }: { metric: (typeof statusMetrics)[0] }) {
+  return (
+    <Card className="shadow-xs overflow-hidden transition-all hover:shadow-md">
+      <CardHeader className="flex flex-row items-center gap-3 pb-2">
+        <div className={cn("rounded-lg p-2", metric.bgColor)}>
+          <metric.icon className={cn("size-5", metric.color)} />
+        </div>
+        <div className="flex-1">
+          <CardDescription className="text-xs">{metric.description}</CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent className="pb-3">
+        <div className="flex items-end justify-between">
+          <div>
+            <p className="font-semibold text-3xl tabular-nums">
+              {metric.numericValue !== undefined
+                ? `${metric.valuePrefix}${metric.numericValue}${metric.valueSuffix}`
+                : metric.value}
+            </p>
+          </div>
+          <div
+            className={cn(
+              "flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium",
+              metric.changeType === "positive" ? "bg-green-500/10 text-green-500" : "bg-red-500/10 text-red-500",
+            )}
+          >
+            {metric.changeType === "positive" ? <ArrowUp className="size-3" /> : <ArrowDown className="size-3" />}
+            {metric.change}
+          </div>
+        </div>
+        <div className="mt-3">
+          <Progress value={metric.progress} className="h-1.5" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PipelineHealthCard() {
+  return (
+    <Card className="shadow-xs">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Pipeline Health</CardTitle>
+            <CardDescription>Stage distribution and momentum</CardDescription>
+          </div>
+          <Button variant="outline" size="sm">
+            View Details
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {pipelineStages.map((stage, index) => (
+            <div key={stage.stage} className="space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{stage.stage}</span>
+                  <Badge variant="outline" className="text-[10px] h-4">
+                    {stage.count}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold tabular-nums">
+                    {formatCurrency(stage.value, { noDecimals: true })}
+                  </span>
+                  <div
+                    className={cn(
+                      "flex items-center gap-1 text-xs font-medium",
+                      stage.trend === "up" ? "text-green-500" : "text-red-500",
+                    )}
+                  >
+                    {stage.trend === "up" ? <TrendingUp className="size-3" /> : <TrendingDown className="size-3" />}
+                    {stage.trendValue}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Progress
+                  value={((index + 1) / pipelineStages.length) * 100}
+                  className={cn(
+                    "h-2",
+                    stage.status === "at-risk"
+                      ? "bg-destructive/20 [&>div]:bg-destructive"
+                      : stage.status === "warning"
+                        ? "bg-yellow-500/20 [&>div]:bg-yellow-500"
+                        : "bg-primary/20 [&>div]:bg-primary",
+                  )}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function QuickStatsCard() {
+  const quickStats = [
+    {
+      label: "Conversion Rate",
+      value: "12.4%",
+      trend: "up",
+      trendValue: "+2.1%",
+    },
+    {
+      label: "Avg Deal Size",
+      value: "$15.2K",
+      trend: "up",
+      trendValue: "+$1.8K",
+    },
+    {
+      label: "Sales Cycle",
+      value: "28 days",
+      trend: "down",
+      trendValue: "-3 days",
+    },
+    {
+      label: "Lead Response",
+      value: "4.2 hours",
+      trend: "up",
+      trendValue: "-1.1h",
+    },
+  ];
+
+  return (
+    <Card className="shadow-xs">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Quick Stats</CardTitle>
+        <CardDescription>Key performance indicators</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {quickStats.map((stat) => (
+          <div key={stat.label} className="flex items-center justify-between">
+            <span className="text-muted-foreground text-sm">{stat.label}</span>
+            <div className="flex items-center gap-2">
+              <span className="font-semibold text-sm tabular-nums">{stat.value}</span>
+              <Badge
+                variant="outline"
+                className={cn(
+                  "h-4 text-[10px]",
+                  stat.trend === "up"
+                    ? "bg-green-500/10 text-green-500 border-green-500/20"
+                    : "bg-red-500/10 text-red-500 border-red-500/20",
+                )}
+              >
+                {stat.trendValue}
+              </Badge>
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ActivitySummaryCard() {
+  const activities = [
+    { type: "call", title: "Demo with Vercel", time: "2h ago", status: "completed" },
+    { type: "email", title: "Proposal sent to OpenAI", time: "4h ago", status: "completed" },
+    { type: "meeting", title: "QBR with Shadcn", time: "Tomorrow 10AM", status: "upcoming" },
+    { type: "followup", title: "Follow up on Astro deal", time: "Today 3PM", status: "overdue" },
+  ];
+
+  return (
+    <Card className="shadow-xs">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Recent Activity</CardTitle>
+        <CardDescription>Latest updates and tasks</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {activities.map((activity, index) => (
+          <div
+            key={index}
+            className={cn(
+              "flex items-start gap-3 rounded-lg border p-3 transition-all hover:bg-muted/50",
+              activity.status === "overdue" && "border-destructive/30 bg-destructive/5",
+              activity.status === "upcoming" && "border-primary/30 bg-primary/5",
+            )}
+          >
+            <div
+              className={cn(
+                "mt-1 rounded-full p-1.5",
+                activity.status === "overdue"
+                  ? "bg-destructive/10"
+                  : activity.status === "upcoming"
+                    ? "bg-primary/10"
+                    : "bg-green-500/10",
+              )}
+            >
+              {activity.status === "completed" ? (
+                <CheckCircle className="size-3 text-green-500" />
+              ) : activity.status === "overdue" ? (
+                <AlertCircle className="size-3 text-destructive" />
+              ) : (
+                <Clock className="size-3 text-primary" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-sm truncate">{activity.title}</p>
+              <p className="text-muted-foreground text-xs">{activity.time}</p>
+            </div>
+            <Badge
+              variant="outline"
+              className={cn(
+                "h-4 text-[10px]",
+                activity.status === "overdue" && "bg-destructive/10 text-destructive border-destructive/20",
+                activity.status === "upcoming" && "bg-primary/10 text-primary border-primary/20",
+                activity.status === "completed" && "bg-green-500/10 text-green-500 border-green-500/20",
+              )}
+            >
+              {activity.status}
+            </Badge>
+          </div>
+        ))}
+      </CardContent>
+      <CardFooter className="pt-0">
+        <Button variant="ghost" size="sm" className="w-full text-primary">
+          View All Activity
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/crm/page.tsx
+++ b/src/app/(main)/dashboard/crm/page.tsx
@@ -1,15 +1,27 @@
+import { ActivityTimeline } from "./_components/activity-timeline";
 import { recentLeadsData } from "./_components/crm.config";
 import { InsightCards } from "./_components/insight-cards";
 import { OperationalCards } from "./_components/operational-cards";
 import { OverviewCards } from "./_components/overview-cards";
+import { PageHeader } from "./_components/page-header";
 import { RecentLeadsTable } from "./_components/recent-leads-table/table";
+import { StatusOverview } from "./_components/status-overview";
 
 export default function Page() {
   return (
     <div className="flex flex-col gap-4 md:gap-6">
+      <PageHeader />
+      <StatusOverview />
       <OverviewCards />
-      <InsightCards />
-      <OperationalCards />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <InsightCards />
+          <OperationalCards />
+        </div>
+        <div className="space-y-4">
+          <ActivityTimeline />
+        </div>
+      </div>
       <RecentLeadsTable data={recentLeadsData} />
     </div>
   );


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three new CRM dashboard components (`PageHeader`, `StatusOverview`, `ActivityTimeline`) and significantly enhances the `RecentLeadsTable` column definitions with richer UI, quick-action buttons, and a contextual dropdown.

- **Hydration mismatch** (`activity-timeline.tsx`): `activityData` and `upcomingTasks` compute dates at module level via `Date.now()`. Because Next.js pre-renders `"use client"` components on the server and re-evaluates the module on the client, `formatDistanceToNow` can produce different strings in each environment, triggering React hydration errors.
- **`Badge` as icon** (`page-header.tsx`): The "Create Proposal" menu item uses `<Badge className="mr-2 size-4" />` with no children, rendering an empty coloured box instead of an icon.

<h3>Confidence Score: 4/5</h3>

Two P1 issues should be addressed before merging: a hydration mismatch from module-level Date.now() and an incorrectly used Badge component as an icon.

The PR is mostly additive UI work but contains two concrete defects: module-level timestamps produce differing server/client renders causing hydration warnings in Next.js, and the empty Badge renders visibly broken UI in the QuickActions menu. The remaining findings are P2 style/data concerns.

activity-timeline.tsx (hydration mismatch) and page-header.tsx (Badge-as-icon, unused import)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/(main)/dashboard/crm/_components/activity-timeline.tsx | New component; module-level Date.now() timestamps cause SSR/client hydration mismatch, and TabsList is missing the `grid` class alongside `grid-cols-2`. |
| src/app/(main)/dashboard/crm/_components/page-header.tsx | New component; Badge is incorrectly used as an icon in QuickActions (renders empty box), and DateRangePicker is imported but never used. |
| src/app/(main)/dashboard/crm/_components/recent-leads-table/columns.tsx | Enhanced columns with richer UI; urgency detection uses fragile single-letter string matching that could produce false positives. |
| src/app/(main)/dashboard/crm/_components/status-overview.tsx | New component with pipeline health cards; progress bars for pipeline stages use index position rather than actual stage counts/values, making them misleading. |
| src/app/(main)/dashboard/crm/page.tsx | Layout restructured to include new PageHeader, StatusOverview, and ActivityTimeline components; changes are clean and straightforward. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Page["crm/page.tsx"]
    Page --> PH["PageHeader\n(page-header.tsx)"]
    Page --> SO["StatusOverview\n(status-overview.tsx)"]
    Page --> OC["OverviewCards"]
    Page --> Grid["2-col grid"]
    Page --> RLT["RecentLeadsTable"]

    Grid --> Left["lg:col-span-2"]
    Grid --> Right["ActivityTimeline\n(activity-timeline.tsx)"]

    Left --> IC["InsightCards"]
    Left --> OpC["OperationalCards"]

    SO --> SC["StatusCard x4"]
    SO --> PHC["PipelineHealthCard"]
    SO --> QSC["QuickStatsCard"]
    SO --> ASC["ActivitySummaryCard"]

    PH --> TR["TimeRangeSelector"]
    PH --> QA["QuickActions"]

    Right --> AT_Tab1["Recent Activity tab"]
    Right --> AT_Tab2["Upcoming Tasks tab"]

    RLT --> Cols["columns.tsx (enhanced)"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/app/(main)/dashboard/crm/_components/page-header.tsx`, line 593-595 ([link](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/blob/ad6ca9f774311d9c1168f462297e512d1e7c2a07/src/app/(main)/dashboard/crm/_components/page-header.tsx#L593-L595)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`Badge` component used as an icon**

   `Badge` is a label/tag UI component, not a lucide-react icon. Rendering it with no children produces a tiny empty coloured box next to "Create Proposal" — likely a copy-paste mistake. A lucide icon (e.g. `FileText` or `FilePlus`) was probably intended here.

   

   Remember to add `FileText` to the lucide-react import.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/(main)/dashboard/crm/_components/page-header.tsx
   Line: 593-595

   Comment:
   **`Badge` component used as an icon**

   `Badge` is a label/tag UI component, not a lucide-react icon. Rendering it with no children produces a tiny empty coloured box next to "Create Proposal" — likely a copy-paste mistake. A lucide icon (e.g. `FileText` or `FilePlus`) was probably intended here.

   

   Remember to add `FileText` to the lucide-react import.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `src/app/(main)/dashboard/crm/_components/page-header.tsx`, line 389 ([link](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/blob/ad6ca9f774311d9c1168f462297e512d1e7c2a07/src/app/(main)/dashboard/crm/_components/page-header.tsx#L389)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unused import**

   `DateRangePicker` is imported but never referenced in this file — the custom-range UI is built inline with `Popover` + `CalendarComponent`. The dead import should be removed.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/(main)/dashboard/crm/_components/page-header.tsx
   Line: 389

   Comment:
   **Unused import**

   `DateRangePicker` is imported but never referenced in this file — the custom-range UI is built inline with `Popover` + `CalendarComponent`. The dead import should be removed.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


3. `src/app/(main)/dashboard/crm/_components/status-overview.tsx`, line 1134-1145 ([link](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/blob/ad6ca9f774311d9c1168f462297e512d1e7c2a07/src/app/(main)/dashboard/crm/_components/status-overview.tsx#L1134-L1145)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Pipeline progress bars show index position, not actual stage data**

   `((index + 1) / pipelineStages.length) * 100` produces evenly-spaced values (20%, 40%, 60%, 80%, 100%) that are independent of each stage's actual `count` or `value`. This makes the bars misleading — a stage with 32 leads gets a shorter bar than one with 5. Consider deriving the progress from the real data:

   ```ts
   const maxCount = Math.max(...pipelineStages.map((s) => s.count));
   // then inside the map:
   value={(stage.count / maxCount) * 100}
   ```

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/(main)/dashboard/crm/_components/status-overview.tsx
   Line: 1134-1145

   Comment:
   **Pipeline progress bars show index position, not actual stage data**

   `((index + 1) / pipelineStages.length) * 100` produces evenly-spaced values (20%, 40%, 60%, 80%, 100%) that are independent of each stage's actual `count` or `value`. This makes the bars misleading — a stage with 32 leads gets a shorter bar than one with 5. Consider deriving the progress from the real data:

   ```ts
   const maxCount = Math.max(...pipelineStages.map((s) => s.count));
   // then inside the map:
   value={(stage.count / maxCount) * 100}
   ```

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/app/(main)/dashboard/crm/_components/activity-timeline.tsx
Line: 40-143

Comment:
**Module-level dates cause SSR/client hydration mismatch**

`activityData` and `upcomingTasks` are module-level constants whose `time`/`dueDate` values are computed from `Date.now()` at module initialisation time. Since this is a `"use client"` component, Next.js pre-renders it on the server and then hydrates on the client. The module is evaluated separately in each environment, so the two `Date.now()` calls capture different timestamps. `formatDistanceToNow` will then produce different strings (e.g. `"2 hours ago"` vs `"3 hours ago"`) when close to a rounding boundary, triggering React hydration warnings.

Move the data inside the component (or into a `useMemo` / `useState` initialiser) so the timestamps are only evaluated once, client-side:

```ts
// inside ActivityTimeline():
const activityData = React.useMemo(() => [
  {
    id: 1,
    time: new Date(Date.now() - 2 * 60 * 60 * 1000),
    // ...
  },
], []);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(main)/dashboard/crm/_components/page-header.tsx
Line: 593-595

Comment:
**`Badge` component used as an icon**

`Badge` is a label/tag UI component, not a lucide-react icon. Rendering it with no children produces a tiny empty coloured box next to "Create Proposal" — likely a copy-paste mistake. A lucide icon (e.g. `FileText` or `FilePlus`) was probably intended here.

```suggestion
          <DropdownMenuItem className="cursor-pointer">
            <FileText className="mr-2 size-4" />
            <span>Create Proposal</span>
```

Remember to add `FileText` to the lucide-react import.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(main)/dashboard/crm/_components/page-header.tsx
Line: 389

Comment:
**Unused import**

`DateRangePicker` is imported but never referenced in this file — the custom-range UI is built inline with `Popover` + `CalendarComponent`. The dead import should be removed.

```suggestion
import { Badge } from "@/components/ui/badge";
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(main)/dashboard/crm/_components/activity-timeline.tsx
Line: 223

Comment:
**`grid-cols-2` without `grid` has no effect**

`grid-cols-2` only applies when the element is `display: grid`. Without the `grid` utility class, `TabsList` remains a flex container and the `grid-cols-2` class is dead. The triggers still fill the row equally because of `flex-1`, so visually it may look correct, but the intent should be made explicit.

```suggestion
          <TabsList className="mb-4 grid w-full grid-cols-2">
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(main)/dashboard/crm/_components/recent-leads-table/columns.tsx
Line: 153-157

Comment:
**Fragile string-based urgency detection**

`activity.includes("d")` matches any string that contains the letter `"d"` (e.g. `"Scheduled"`, `"Qualified"`, `"Pending"`). Combined with `includes("ago")`, a string like `"Scheduled 2 ago"` would be false-positive flagged as urgent. Similarly `includes("m")` matches `"some"` or `"tomorrow"`. Prefer a more precise pattern, such as a regex that anchors the unit to the end of the token:

```ts
const isUrgent = /\d+\s*d(ay)?s?\s+ago/i.test(activity);
const isRecent = /\d+\s*[mh]\s+ago/i.test(activity);
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/app/(main)/dashboard/crm/_components/status-overview.tsx
Line: 1134-1145

Comment:
**Pipeline progress bars show index position, not actual stage data**

`((index + 1) / pipelineStages.length) * 100` produces evenly-spaced values (20%, 40%, 60%, 80%, 100%) that are independent of each stage's actual `count` or `value`. This makes the bars misleading — a stage with 32 leads gets a shorter bar than one with 5. Consider deriving the progress from the real data:

```ts
const maxCount = Math.max(...pipelineStages.map((s) => s.count));
// then inside the map:
value={(stage.count / maxCount) * 100}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["round1 crm homepage upgrade"](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/ad6ca9f774311d9c1168f462297e512d1e7c2a07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28745713)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->