### PR TITLE
feat: added search at sidebar

### DIFF
--- a/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
@@ -78,28 +78,28 @@ export function SearchDialog() {
   const router = useRouter();
 
   React.useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(query), 500);
+    const timer = setTimeout(() => setDebouncedQuery(query), 150);
     return () => clearTimeout(timer);
   }, [query]);
 
-  React.useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === "j" && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        setOpen((prev) => !prev);
-      }
-    };
-    document.addEventListener("keydown", down);
-    return () => document.removeEventListener("keydown", down);
-  }, []);
-
-  const handleOpenChange = (value: boolean) => {
+  const handleOpenChange = React.useCallback((value: boolean) => {
     setOpen(value);
     if (!value) {
       setQuery("");
       setDebouncedQuery("");
     }
-  };
+  }, []);
+
+  React.useEffect(() => {
+    const down = (e: KeyboardEvent) => {
+      if (e.key === "j" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        handleOpenChange(!open);
+      }
+    };
+    document.addEventListener("keydown", down);
+    return () => document.removeEventListener("keydown", down);
+  }, [open, handleOpenChange]);
 
   const handleSelect = (item: SearchItem) => {
     if (item.disabled) return;

--- a/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import { useRouter } from "next/navigation";
 
-import { ChartBar, Forklift, Gauge, GraduationCap, LayoutDashboard, Search, ShoppingBag } from "lucide-react";
+import { Search } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,72 +30,17 @@ type SearchItem = {
   newTab?: boolean;
 };
 
-const recommendations: SearchItem[] = [
-  {
-    group: "Dashboards",
-    icon: LayoutDashboard,
-    label: "Default",
-    url: "/dashboard/default",
-  },
-  { group: "Dashboards", icon: ChartBar, label: "CRM", url: "/dashboard/crm" },
-  {
-    group: "Dashboards",
-    icon: Gauge,
-    label: "Analytics",
-    url: "/dashboard/analytics",
-  },
-  {
-    group: "Dashboards",
-    icon: ShoppingBag,
-    label: "E-Commerce",
-    url: "/dashboard/coming-soon",
-    disabled: true,
-  },
-  {
-    group: "Dashboards",
-    icon: GraduationCap,
-    label: "Academy",
-    url: "/dashboard/coming-soon",
-    disabled: true,
-  },
-  {
-    group: "Dashboards",
-    icon: Forklift,
-    label: "Logistics",
-    url: "/dashboard/coming-soon",
-    disabled: true,
-  },
-  {
-    group: "Authentication",
-    label: "Login v1",
-    url: "/auth/v1/login",
-    newTab: true,
-  },
-  {
-    group: "Authentication",
-    label: "Login v2",
-    url: "/auth/v2/login",
-    newTab: true,
-  },
-  {
-    group: "Authentication",
-    label: "Register v1",
-    url: "/auth/v1/register",
-    newTab: true,
-  },
-  {
-    group: "Authentication",
-    label: "Register v2",
-    url: "/auth/v2/register",
-    newTab: true,
-  },
-];
+const sidebarGroupLabels = new Set(sidebarItems.flatMap((group) => (group.label ? [group.label] : [])));
 
-const searchIndex: SearchItem[] = sidebarItems.flatMap((group) =>
+function getSubItemGroup(groupLabel: string | undefined, itemTitle: string) {
+  return sidebarGroupLabels.has(itemTitle) ? (groupLabel ?? "Other") : itemTitle;
+}
+
+const searchItems: SearchItem[] = sidebarItems.flatMap((group) =>
   group.items.flatMap((item) => {
     if (item.subItems) {
       return item.subItems.map((sub) => ({
-        group: group.label ?? "Other",
+        group: getSubItemGroup(group.label, item.title),
         label: sub.title,
         url: sub.url,
         icon: item.icon,
@@ -115,6 +60,12 @@ const searchIndex: SearchItem[] = sidebarItems.flatMap((group) =>
     ];
   }),
 );
+
+function getAvailableItems(items: SearchItem[]) {
+  return items.filter((item) => !item.disabled && !item.url.includes("coming-soon"));
+}
+
+const recommendations = getAvailableItems(searchItems);
 
 function groupBy(items: SearchItem[]) {
   const groups = [...new Set(items.map((item) => item.group))];
@@ -149,7 +100,7 @@ export function SearchDialog() {
     if (item.disabled) return;
     handleOpenChange(false);
     if (item.newTab) {
-      window.open(item.url, "_blank", "noreferrer");
+      window.open(item.url, "_blank", "noopener,noreferrer");
     } else {
       router.push(item.url);
     }
@@ -161,11 +112,20 @@ export function SearchDialog() {
         {index > 0 && <CommandSeparator />}
         <CommandGroup heading={group}>
           {groupItems.map((item) => (
-            <CommandItem disabled={item.disabled} key={`${group}-${item.label}`} onSelect={() => handleSelect(item)}>
+            <CommandItem
+              disabled={item.disabled}
+              key={`${group}-${item.url}-${item.label}`}
+              value={`${item.group} ${item.label}`}
+              onSelect={() => handleSelect(item)}
+            >
               {item.icon && <item.icon />}
               <span>{item.label}</span>
 
-              {item.disabled && <Badge className="rounded-md bg-gray-200 dark:text-gray-800 text-black">Soon</Badge>}
+              {item.disabled && (
+                <Badge variant="outline" className="text-xs">
+                  Soon
+                </Badge>
+              )}
             </CommandItem>
           ))}
         </CommandGroup>
@@ -175,7 +135,7 @@ export function SearchDialog() {
   return (
     <>
       <Button
-        onClick={() => setOpen(true)}
+        onClick={() => handleOpenChange(true)}
         variant="link"
         className="px-0! font-normal text-muted-foreground hover:no-underline"
       >
@@ -190,7 +150,7 @@ export function SearchDialog() {
           <CommandInput placeholder="Search dashboards, users, and more…" value={query} onValueChange={setQuery} />
           <CommandList>
             <CommandEmpty>No results found.</CommandEmpty>
-            {query ? renderGroups(searchIndex) : renderGroups(recommendations)}
+            {query ? renderGroups(searchItems) : renderGroups(recommendations)}
           </CommandList>
         </Command>
       </CommandDialog>

--- a/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
@@ -1,10 +1,12 @@
 "use client";
+
 import * as React from "react";
 
 import { useRouter } from "next/navigation";
 
 import { ChartBar, Forklift, Gauge, GraduationCap, LayoutDashboard, Search, ShoppingBag } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -29,16 +31,64 @@ type SearchItem = {
 };
 
 const recommendations: SearchItem[] = [
-  { group: "Dashboards", icon: LayoutDashboard, label: "Default", url: "/dashboard/default" },
+  {
+    group: "Dashboards",
+    icon: LayoutDashboard,
+    label: "Default",
+    url: "/dashboard/default",
+  },
   { group: "Dashboards", icon: ChartBar, label: "CRM", url: "/dashboard/crm" },
-  { group: "Dashboards", icon: Gauge, label: "Analytics", url: "/dashboard/analytics" },
-  { group: "Dashboards", icon: ShoppingBag, label: "E-Commerce", url: "/dashboard/coming-soon", disabled: true },
-  { group: "Dashboards", icon: GraduationCap, label: "Academy", url: "/dashboard/coming-soon", disabled: true },
-  { group: "Dashboards", icon: Forklift, label: "Logistics", url: "/dashboard/coming-soon", disabled: true },
-  { group: "Authentication", label: "Login v1", url: "/auth/v1/login", newTab: true },
-  { group: "Authentication", label: "Login v2", url: "/auth/v2/login", newTab: true },
-  { group: "Authentication", label: "Register v1", url: "/auth/v1/register", newTab: true },
-  { group: "Authentication", label: "Register v2", url: "/auth/v2/register", newTab: true },
+  {
+    group: "Dashboards",
+    icon: Gauge,
+    label: "Analytics",
+    url: "/dashboard/analytics",
+  },
+  {
+    group: "Dashboards",
+    icon: ShoppingBag,
+    label: "E-Commerce",
+    url: "/dashboard/coming-soon",
+    disabled: true,
+  },
+  {
+    group: "Dashboards",
+    icon: GraduationCap,
+    label: "Academy",
+    url: "/dashboard/coming-soon",
+    disabled: true,
+  },
+  {
+    group: "Dashboards",
+    icon: Forklift,
+    label: "Logistics",
+    url: "/dashboard/coming-soon",
+    disabled: true,
+  },
+  {
+    group: "Authentication",
+    label: "Login v1",
+    url: "/auth/v1/login",
+    newTab: true,
+  },
+  {
+    group: "Authentication",
+    label: "Login v2",
+    url: "/auth/v2/login",
+    newTab: true,
+  },
+  {
+    group: "Authentication",
+    label: "Register v1",
+    url: "/auth/v1/register",
+    newTab: true,
+  },
+  {
+    group: "Authentication",
+    label: "Register v2",
+    url: "/auth/v2/register",
+    newTab: true,
+  },
 ];
 
 const searchIndex: SearchItem[] = sidebarItems.flatMap((group) =>
@@ -68,38 +118,32 @@ const searchIndex: SearchItem[] = sidebarItems.flatMap((group) =>
 
 function groupBy(items: SearchItem[]) {
   const groups = [...new Set(items.map((item) => item.group))];
-  return groups.map((group) => ({ group, items: items.filter((item) => item.group === group) }));
+  return groups.map((group) => ({
+    group,
+    items: items.filter((item) => item.group === group),
+  }));
 }
 
 export function SearchDialog() {
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
-  const [debouncedQuery, setDebouncedQuery] = React.useState("");
   const router = useRouter();
-
-  React.useEffect(() => {
-    const timer = setTimeout(() => setDebouncedQuery(query), 150);
-    return () => clearTimeout(timer);
-  }, [query]);
-
-  const handleOpenChange = React.useCallback((value: boolean) => {
-    setOpen(value);
-    if (!value) {
-      setQuery("");
-      setDebouncedQuery("");
-    }
-  }, []);
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "j" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        handleOpenChange(!open);
+        setOpen((prev) => !prev);
       }
     };
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
-  }, [open, handleOpenChange]);
+  }, []);
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    if (!value) setQuery("");
+  };
 
   const handleSelect = (item: SearchItem) => {
     if (item.disabled) return;
@@ -111,15 +155,6 @@ export function SearchDialog() {
     }
   };
 
-  const searchResults = React.useMemo(() => {
-    if (!debouncedQuery.trim()) return null;
-    const q = debouncedQuery.toLowerCase();
-    return searchIndex.filter((item) => item.label.toLowerCase().includes(q) || item.group.toLowerCase().includes(q));
-  }, [debouncedQuery]);
-
-  const isSearching = query.trim() !== "" && debouncedQuery !== query;
-  const showRecommendations = query.trim() === "";
-
   const renderGroups = (items: SearchItem[]) =>
     groupBy(items).map(({ group, items: groupItems }, index) => (
       <React.Fragment key={group}>
@@ -129,6 +164,8 @@ export function SearchDialog() {
             <CommandItem disabled={item.disabled} key={`${group}-${item.label}`} onSelect={() => handleSelect(item)}>
               {item.icon && <item.icon />}
               <span>{item.label}</span>
+
+              {item.disabled && <Badge className="rounded-md bg-gray-200 dark:text-gray-800 text-black">Soon</Badge>}
             </CommandItem>
           ))}
         </CommandGroup>
@@ -149,19 +186,11 @@ export function SearchDialog() {
         </kbd>
       </Button>
       <CommandDialog open={open} onOpenChange={handleOpenChange}>
-        <Command shouldFilter={false}>
+        <Command>
           <CommandInput placeholder="Search dashboards, users, and more…" value={query} onValueChange={setQuery} />
           <CommandList>
-            {showRecommendations && renderGroups(recommendations)}
-            {!showRecommendations && isSearching && (
-              <p className="py-6 text-center text-sm text-muted-foreground">Searching…</p>
-            )}
-            {!showRecommendations && !isSearching && searchResults !== null && (
-              <>
-                <CommandEmpty>No results found.</CommandEmpty>
-                {renderGroups(searchResults)}
-              </>
-            )}
+            <CommandEmpty>No results found.</CommandEmpty>
+            {query ? renderGroups(searchIndex) : renderGroups(recommendations)}
           </CommandList>
         </Command>
       </CommandDialog>

--- a/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx
@@ -1,6 +1,8 @@
 "use client";
 import * as React from "react";
 
+import { useRouter } from "next/navigation";
+
 import { ChartBar, Forklift, Gauge, GraduationCap, LayoutDashboard, Search, ShoppingBag } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -14,34 +16,124 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
+import type { NavMainItem } from "@/navigation/sidebar/sidebar-items";
+import { sidebarItems } from "@/navigation/sidebar/sidebar-items";
 
-const searchItems = [
-  { group: "Dashboards", icon: LayoutDashboard, label: "Default" },
-  { group: "Dashboards", icon: ChartBar, label: "CRM" },
-  { group: "Dashboards", icon: Gauge, label: "Analytics" },
-  { group: "Dashboards", icon: ShoppingBag, label: "E-Commerce", disabled: true },
-  { group: "Dashboards", icon: GraduationCap, label: "Academy", disabled: true },
-  { group: "Dashboards", icon: Forklift, label: "Logistics", disabled: true },
-  { group: "Authentication", label: "Login v1" },
-  { group: "Authentication", label: "Login v2" },
-  { group: "Authentication", label: "Register v1" },
-  { group: "Authentication", label: "Register v2" },
+type SearchItem = {
+  group: string;
+  label: string;
+  url: string;
+  icon?: NavMainItem["icon"];
+  disabled?: boolean;
+  newTab?: boolean;
+};
+
+const recommendations: SearchItem[] = [
+  { group: "Dashboards", icon: LayoutDashboard, label: "Default", url: "/dashboard/default" },
+  { group: "Dashboards", icon: ChartBar, label: "CRM", url: "/dashboard/crm" },
+  { group: "Dashboards", icon: Gauge, label: "Analytics", url: "/dashboard/analytics" },
+  { group: "Dashboards", icon: ShoppingBag, label: "E-Commerce", url: "/dashboard/coming-soon", disabled: true },
+  { group: "Dashboards", icon: GraduationCap, label: "Academy", url: "/dashboard/coming-soon", disabled: true },
+  { group: "Dashboards", icon: Forklift, label: "Logistics", url: "/dashboard/coming-soon", disabled: true },
+  { group: "Authentication", label: "Login v1", url: "/auth/v1/login", newTab: true },
+  { group: "Authentication", label: "Login v2", url: "/auth/v2/login", newTab: true },
+  { group: "Authentication", label: "Register v1", url: "/auth/v1/register", newTab: true },
+  { group: "Authentication", label: "Register v2", url: "/auth/v2/register", newTab: true },
 ];
+
+const searchIndex: SearchItem[] = sidebarItems.flatMap((group) =>
+  group.items.flatMap((item) => {
+    if (item.subItems) {
+      return item.subItems.map((sub) => ({
+        group: group.label ?? "Other",
+        label: sub.title,
+        url: sub.url,
+        icon: item.icon,
+        disabled: sub.comingSoon,
+        newTab: sub.newTab,
+      }));
+    }
+    return [
+      {
+        group: group.label ?? "Other",
+        label: item.title,
+        url: item.url,
+        icon: item.icon,
+        disabled: item.comingSoon,
+        newTab: item.newTab,
+      },
+    ];
+  }),
+);
+
+function groupBy(items: SearchItem[]) {
+  const groups = [...new Set(items.map((item) => item.group))];
+  return groups.map((group) => ({ group, items: items.filter((item) => item.group === group) }));
+}
 
 export function SearchDialog() {
   const [open, setOpen] = React.useState(false);
-  const groups = [...new Set(searchItems.map((item) => item.group))];
+  const [query, setQuery] = React.useState("");
+  const [debouncedQuery, setDebouncedQuery] = React.useState("");
+  const router = useRouter();
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), 500);
+    return () => clearTimeout(timer);
+  }, [query]);
 
   React.useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "j" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setOpen((open) => !open);
+        setOpen((prev) => !prev);
       }
     };
     document.addEventListener("keydown", down);
     return () => document.removeEventListener("keydown", down);
   }, []);
+
+  const handleOpenChange = (value: boolean) => {
+    setOpen(value);
+    if (!value) {
+      setQuery("");
+      setDebouncedQuery("");
+    }
+  };
+
+  const handleSelect = (item: SearchItem) => {
+    if (item.disabled) return;
+    handleOpenChange(false);
+    if (item.newTab) {
+      window.open(item.url, "_blank", "noreferrer");
+    } else {
+      router.push(item.url);
+    }
+  };
+
+  const searchResults = React.useMemo(() => {
+    if (!debouncedQuery.trim()) return null;
+    const q = debouncedQuery.toLowerCase();
+    return searchIndex.filter((item) => item.label.toLowerCase().includes(q) || item.group.toLowerCase().includes(q));
+  }, [debouncedQuery]);
+
+  const isSearching = query.trim() !== "" && debouncedQuery !== query;
+  const showRecommendations = query.trim() === "";
+
+  const renderGroups = (items: SearchItem[]) =>
+    groupBy(items).map(({ group, items: groupItems }, index) => (
+      <React.Fragment key={group}>
+        {index > 0 && <CommandSeparator />}
+        <CommandGroup heading={group}>
+          {groupItems.map((item) => (
+            <CommandItem disabled={item.disabled} key={`${group}-${item.label}`} onSelect={() => handleSelect(item)}>
+              {item.icon && <item.icon />}
+              <span>{item.label}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </React.Fragment>
+    ));
 
   return (
     <>
@@ -56,34 +148,20 @@ export function SearchDialog() {
           <span className="text-xs">⌘</span>J
         </kbd>
       </Button>
-      <CommandDialog open={open} onOpenChange={setOpen}>
-        <Command>
-          <CommandInput placeholder="Search dashboards, users, and more…" />
+      <CommandDialog open={open} onOpenChange={handleOpenChange}>
+        <Command shouldFilter={false}>
+          <CommandInput placeholder="Search dashboards, users, and more…" value={query} onValueChange={setQuery} />
           <CommandList>
-            <CommandEmpty>No results found.</CommandEmpty>
-            {groups.map((group, index) => (
-              <React.Fragment key={group}>
-                {index > 0 && <CommandSeparator />}
-                <CommandGroup heading={group}>
-                  {searchItems
-                    .filter((item) => item.group === group)
-                    .map((item) => (
-                      <CommandItem
-                        disabled={item.disabled}
-                        key={item.label}
-                        onSelect={() => {
-                          if (!item.disabled) {
-                            setOpen(false);
-                          }
-                        }}
-                      >
-                        {item.icon && <item.icon />}
-                        <span>{item.label}</span>
-                      </CommandItem>
-                    ))}
-                </CommandGroup>
-              </React.Fragment>
-            ))}
+            {showRecommendations && renderGroups(recommendations)}
+            {!showRecommendations && isSearching && (
+              <p className="py-6 text-center text-sm text-muted-foreground">Searching…</p>
+            )}
+            {!showRecommendations && !isSearching && searchResults !== null && (
+              <>
+                <CommandEmpty>No results found.</CommandEmpty>
+                {renderGroups(searchResults)}
+              </>
+            )}
           </CommandList>
         </Command>
       </CommandDialog>


### PR DESCRIPTION
Added search bar with dynamic list which gets the routes from sidebarItems, so that the search will be up to date with links of sidebar. Still kept the previous hardcoded list of search items, however now they serve as a recommendation

Before pushing tested with lint, build, and with AI (playwrite mcp) everything passed

Fixes #50

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the static, hardcoded search list in `SearchDialog` with one derived dynamically from `sidebarItems`, so the dialog stays in sync as navigation items are added or changed. Non-disabled items become "recommendations" shown when the input is empty, while typing exposes all entries (including coming-soon ones) with a "Soon" badge.

The implementation is solid overall. The one pre-existing gap — `setOpen` called directly in the Ctrl+J handler, bypassing `handleOpenChange` and leaving `query` stale — was already raised in a prior review thread and is not repeated here.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no new P0/P1 defects introduced; all outstanding issues were already flagged in prior review threads.

Only P2-level concerns remain. The dynamic search derivation from sidebarItems is correct, key collisions are avoided, new-tab handling is safe, and disabled items are guarded at both the cmdk and handler levels.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/(main)/dashboard/_components/sidebar/search-dialog.tsx | Replaces the hardcoded search list with a dynamically derived one from sidebarItems; introduces query-controlled filtering, handleOpenChange for cleanup, new-tab navigation, and a Soon badge for disabled items. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User interaction] --> B{Trigger}
    B -->|Click Search button| C["handleOpenChange(true)"]
    B -->|"Ctrl+J"| D["setOpen toggle - bypasses handleOpenChange"]
    C --> E[Dialog opens]
    D --> E
    E --> F[User types in CommandInput]
    F --> G{query empty?}
    G -->|Yes| H["renderGroups recommendations - non-disabled items only"]
    G -->|No| I["renderGroups searchItems - all items incl. disabled"]
    H --> J[CommandItem onSelect]
    I --> J
    J --> K{item.newTab?}
    K -->|Yes| L["window.open blank tab"]
    K -->|No| M["router.push"]
    L --> N["handleOpenChange false - resets query"]
    M --> N
```

<sub>Reviews (4): Last reviewed commit: ["Derive search dialog items from sidebar"](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/b11292bf1f3a13efaac1901517d413661db3e3aa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29653726)</sub>

<!-- /greptile_comment -->