### PR TITLE
Add ecommerce dashboard

### DIFF
--- a/src/app/(main)/dashboard/ecommerce/_components/customer-reviews.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/customer-reviews.tsx
@@ -1,0 +1,71 @@
+import { ArrowLeft, ArrowRight, ArrowUpRight, Star } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarGroup, AvatarGroupCount } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+const customerInitials = ["EM", "OW", "NO", "MM"] as const;
+
+export function CustomerReviews() {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="font-normal text-muted-foreground text-sm">Reviews</CardTitle>
+        <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">
+          4.6 average rating
+        </CardDescription>
+        <CardAction>
+          <ArrowUpRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        <div className="rounded-lg bg-muted p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-0.5 text-foreground">
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+                <Star className="size-3.5 fill-current" />
+              </div>
+              <div>
+                <div className="font-medium text-sm">Melody Macy</div>
+                <p className="mt-2 line-clamp-3 text-muted-foreground text-sm">
+                  The linen overshirt arrived faster than expected and the fit was exactly right.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-1">
+              <Button aria-label="Previous review" size="icon-xs" variant="outline">
+                <ArrowLeft />
+              </Button>
+              <Button aria-label="Next review" size="icon-xs" variant="outline">
+                <ArrowRight />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 rounded-lg border px-4 py-3">
+          <div className="min-w-0">
+            <div className="font-medium text-sm">12.8K reviews</div>
+            <div className="text-muted-foreground text-xs">Customers reviewed this month</div>
+          </div>
+
+          <AvatarGroup>
+            {customerInitials.map((initials) => (
+              <Avatar key={initials}>
+                <AvatarFallback>{initials}</AvatarFallback>
+              </Avatar>
+            ))}
+
+            <AvatarGroupCount>+42</AvatarGroupCount>
+          </AvatarGroup>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/inventory.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/inventory.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { ArrowUpRight, PackageCheck, PackageX, TriangleAlert } from "lucide-react";
+import { Label, Pie, PieChart } from "recharts";
+
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+import { Separator } from "@/components/ui/separator";
+
+const chartData = [{ month: "current", "in-stock": 760, "low-stock": 320, "out-of-stock": 160 }];
+const totalUnits = chartData[0]["in-stock"] + chartData[0]["low-stock"] + chartData[0]["out-of-stock"];
+const availablePercent = Math.round((chartData[0]["in-stock"] / totalUnits) * 100);
+const gaugeSegmentCount = 32;
+const inStockSegments = Math.round((chartData[0]["in-stock"] / totalUnits) * gaugeSegmentCount);
+const lowStockSegments = Math.round((chartData[0]["low-stock"] / totalUnits) * gaugeSegmentCount);
+const gaugeSegments = Array.from({ length: gaugeSegmentCount }, (_, index) => {
+  const status =
+    index < inStockSegments ? "in-stock" : index < inStockSegments + lowStockSegments ? "low-stock" : "out-of-stock";
+
+  return {
+    fill: `var(--color-${status})`,
+    id: `segment-${index + 1}`,
+    status,
+    value: 1,
+  };
+});
+const inventorySummary = [
+  {
+    icon: PackageCheck,
+    label: "In stock",
+    value: chartData[0]["in-stock"],
+  },
+  {
+    icon: TriangleAlert,
+    label: "Low stock",
+    value: chartData[0]["low-stock"],
+  },
+  {
+    icon: PackageX,
+    label: "Out",
+    value: chartData[0]["out-of-stock"],
+  },
+] as const;
+
+const chartConfig = {
+  "in-stock": {
+    label: "In stock",
+    color: "var(--chart-2)",
+  },
+  "low-stock": {
+    label: "Low stock",
+    color: "var(--chart-1)",
+  },
+  "out-of-stock": {
+    label: "Out of stock",
+    color: "var(--destructive)",
+  },
+} satisfies ChartConfig;
+
+export function Inventory() {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="font-normal text-muted-foreground text-sm">Inventory</CardTitle>
+        <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">
+          {availablePercent}% available
+        </CardDescription>
+        <CardAction>
+          <ArrowUpRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <ChartContainer config={chartConfig} className="mx-auto h-30 w-full">
+          <PieChart>
+            <Pie
+              cx="50%"
+              cy="100%"
+              cornerRadius={6}
+              data={gaugeSegments}
+              dataKey="value"
+              endAngle={0}
+              innerRadius={80}
+              outerRadius={110}
+              paddingAngle={2}
+              startAngle={180}
+              stroke="var(--card)"
+              strokeWidth={1}
+            >
+              <Label
+                content={({ viewBox }) => {
+                  if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                    return (
+                      <text textAnchor="middle" x={viewBox.cx} y={viewBox.cy}>
+                        <tspan
+                          className="fill-foreground font-medium text-2xl tabular-nums"
+                          x={viewBox.cx}
+                          y={(viewBox.cy || 0) + 22}
+                        >
+                          {availablePercent}%
+                        </tspan>
+                        <tspan className="fill-muted-foreground text-xs" x={viewBox.cx} y={(viewBox.cy || 0) + 38}>
+                          Available
+                        </tspan>
+                      </text>
+                    );
+                  }
+                }}
+              />
+            </Pie>
+          </PieChart>
+        </ChartContainer>
+        <Separator />
+
+        <div className="grid grid-cols-3 divide-x">
+          {inventorySummary.map((item, _index) => (
+            <div key={item.label} className="flex flex-col items-center gap-3 text-center">
+              <div className="grid size-9 place-items-center rounded-full bg-muted">
+                <item.icon className="size-4 text-muted-foreground" />
+              </div>
+              <div>
+                <div className="text-muted-foreground text-xs leading-none">{item.label}</div>
+                <div className="font-medium text-sm tabular-nums">{item.value.toLocaleString()}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { format, parse } from "date-fns";
 import { ArrowUpRight, DollarSign, PackageCheck, ReceiptText, RotateCcw, ShoppingBag, Users } from "lucide-react";
 import { Area, Bar, CartesianGrid, ComposedChart, XAxis, YAxis } from "recharts";
 
@@ -70,10 +71,16 @@ function formatMonthTick(value: string) {
 function formatTooltipLabel(value: string) {
   const parts = value.split(" ");
   const range = parts.at(-1);
-  const month = parts.slice(0, -1).join(" ");
+  const month = parse(parts.slice(0, -1).join(" "), "MMM yy", new Date());
   const [start, end] = String(range).split("-");
+  const startDate = new Date(month.getFullYear(), month.getMonth(), Number(start));
+  const endDate = new Date(month.getFullYear(), month.getMonth(), Number(end));
 
-  return `${month}, ${Number(start)} - ${Number(end)}`;
+  return `${format(month, "MMM")} ${format(startDate, "do")} - ${format(endDate, "do")}, ${format(month, "yyyy")}`;
+}
+
+function formatCurrencyTooltipValue(value: unknown) {
+  return typeof value === "number" ? `$${value.toLocaleString()}` : String(value ?? "");
 }
 
 export function KpiStrip() {
@@ -232,7 +239,28 @@ export function KpiStrip() {
                   <YAxis yAxisId="revenue" hide domain={[3000, 10_000]} />
                   <YAxis yAxisId="profit" hide domain={[0, 6000]} />
                   <ChartTooltip
-                    content={<ChartTooltipContent labelFormatter={(value) => formatTooltipLabel(String(value))} />}
+                    content={
+                      <ChartTooltipContent
+                        className="w-40"
+                        labelFormatter={(value) => formatTooltipLabel(String(value))}
+                        formatter={(value, name, item) => (
+                          <>
+                            <div
+                              className="size-2.5 shrink-0 rounded-[2px]"
+                              style={{
+                                backgroundColor: item.color,
+                              }}
+                            />
+                            <div className="flex flex-1 items-center justify-between leading-none">
+                              <span className="text-muted-foreground">{String(name ?? "")}</span>
+                              <span className="font-medium font-mono text-foreground tabular-nums">
+                                {formatCurrencyTooltipValue(value)}
+                              </span>
+                            </div>
+                          </>
+                        )}
+                      />
+                    }
                     cursor={{
                       stroke: "var(--border)",
                       strokeDasharray: "4 4",
@@ -252,6 +280,7 @@ export function KpiStrip() {
                     dataKey="revenue"
                     fill="none"
                     filter="url(#sales-line-glow)"
+                    name="Revenue"
                     stroke="var(--color-revenue)"
                     strokeWidth={1.8}
                     type="linear"

--- a/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
@@ -73,8 +73,9 @@ function formatTooltipLabel(value: string) {
   const range = parts.at(-1);
   const month = parse(parts.slice(0, -1).join(" "), "MMM yy", new Date());
   const [start, end] = String(range).split("-");
+  const lastDayOfMonth = new Date(month.getFullYear(), month.getMonth() + 1, 0).getDate();
   const startDate = new Date(month.getFullYear(), month.getMonth(), Number(start));
-  const endDate = new Date(month.getFullYear(), month.getMonth(), Number(end));
+  const endDate = new Date(month.getFullYear(), month.getMonth(), Math.min(Number(end), lastDayOfMonth));
 
   return `${format(month, "MMM")} ${format(startDate, "do")} - ${format(endDate, "do")}, ${format(month, "yyyy")}`;
 }

--- a/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
@@ -217,7 +217,7 @@ export function KpiStrip() {
                       </feMerge>
                     </filter>
                   </defs>
-                  <CartesianGrid xAxisId="revenue" yAxisId="profit" vertical={false} />
+                  <CartesianGrid yAxisId="profit" vertical={false} />
                   <XAxis
                     dataKey="period"
                     axisLine={false}

--- a/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
@@ -200,7 +200,7 @@ export function KpiStrip() {
             </CardHeader>
 
             <CardContent>
-              <ChartContainer config={revenueOverviewConfig} className="h-72 w-full">
+              <ChartContainer config={revenueOverviewConfig} className="h-74 w-full">
                 <ComposedChart
                   accessibilityLayer
                   data={revenueOverviewData}

--- a/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import { ArrowUpRight, DollarSign, PackageCheck, ReceiptText, RotateCcw, ShoppingBag, Users } from "lucide-react";
+import { Area, Bar, CartesianGrid, ComposedChart, XAxis, YAxis } from "recharts";
+
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+
+const revenueBucketRanges = ["01-05", "06-10", "11-15", "16-20", "21-25", "26-31"] as const;
+
+const revenueBucketValues = [
+  [4820, 5150, 5060, 5520, 5990, 6880],
+  [5140, 5360, 5520, 5860, 6120, 6720],
+  [4920, 4680, 5150, 5360, 5720, 6150],
+  [5480, 5920, 5660, 6180, 6340, 6660],
+  [5840, 6220, 6480, 6110, 6680, 7230],
+  [6280, 6740, 6960, 7120, 6780, 7240],
+  [6820, 7240, 7680, 7410, 7920, 7810],
+  [6040, 6420, 6150, 6860, 7080, 7090],
+  [5860, 6120, 6340, 6080, 6620, 6900],
+  [6520, 6840, 7060, 7420, 7160, 8280],
+  [6980, 7320, 7640, 7160, 8040, 8620],
+  [6900, 7400, 8100, 8600, 8200, 9360],
+] as const;
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short" });
+
+function getRollingRevenueBuckets() {
+  const currentMonth = new Date();
+  currentMonth.setDate(1);
+
+  return revenueBucketValues.map((values, index) => {
+    const monthDate = new Date(currentMonth);
+    monthDate.setMonth(currentMonth.getMonth() - (revenueBucketValues.length - 1 - index));
+
+    return {
+      month: `${monthFormatter.format(monthDate)} ${String(monthDate.getFullYear()).slice(-2)}`,
+      values,
+    };
+  });
+}
+
+const revenueOverviewData = getRollingRevenueBuckets().flatMap(({ month, values }) =>
+  values.map((revenue, index) => ({
+    period: `${month} ${revenueBucketRanges[index]}`,
+    profit: Math.round(revenue * (index % 3 === 0 ? 0.24 : index % 3 === 1 ? 0.28 : 0.26)),
+    revenue,
+  })),
+);
+
+const revenueOverviewConfig = {
+  revenue: {
+    label: "Revenue",
+    color: "var(--foreground)",
+  },
+  profit: {
+    label: "Profit",
+    color: "var(--muted-foreground)",
+  },
+} satisfies ChartConfig;
+
+function formatMonthTick(value: string) {
+  const parts = value.split(" ");
+  const range = parts.at(-1);
+  const month = parts.slice(0, -1).join(" ");
+
+  return range === "11-15" ? month : "";
+}
+
+function formatTooltipLabel(value: string) {
+  const parts = value.split(" ");
+  const range = parts.at(-1);
+  const month = parts.slice(0, -1).join(" ");
+  const [start, end] = String(range).split("-");
+
+  return `${month}, ${Number(start)} - ${Number(end)}`;
+}
+
+export function KpiStrip() {
+  return (
+    <div className="h-full overflow-hidden rounded-xl bg-card ring-1 ring-foreground/10 xl:col-span-12">
+      <div>
+        <div className="grid grid-cols-1 xl:grid-cols-12">
+          <div className="grid grid-cols-1 md:grid-cols-2 md:grid-rows-3 xl:col-span-5 xl:border-r">
+            <Card className="h-full rounded-none border-0 border-border border-b ring-0 md:border-r">
+              <CardHeader>
+                <CardTitle className="font-normal text-sm">Total Sales</CardTitle>
+                <CardDescription className="text-3xl text-foreground tabular-nums leading-none tracking-tight">
+                  $48,560.00
+                </CardDescription>
+                <CardAction className="grid size-6 place-items-center rounded-sm bg-muted">
+                  <DollarSign className="size-3 text-foreground" />
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm">
+                  <span className="text-green-700 dark:text-green-300">+15.8%</span>
+                  <span className="text-muted-foreground"> vs last week</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="h-full rounded-none border-0 border-border border-b ring-0">
+              <CardHeader>
+                <CardTitle className="font-normal text-sm">Total Orders</CardTitle>
+                <CardDescription className="text-3xl text-foreground tabular-nums leading-none tracking-tight">
+                  379
+                </CardDescription>
+                <CardAction className="grid size-6 place-items-center rounded-sm bg-muted">
+                  <ShoppingBag className="size-3 text-foreground" />
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm">
+                  <span className="text-green-700 dark:text-green-300">+8.3%</span>
+                  <span className="text-muted-foreground"> vs last week</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="h-full rounded-none border-0 border-border border-b ring-0 md:border-r">
+              <CardHeader>
+                <CardTitle className="font-normal text-sm">Customer Growth</CardTitle>
+                <CardDescription className="text-3xl text-foreground tabular-nums leading-none tracking-tight">
+                  820
+                </CardDescription>
+                <CardAction className="grid size-6 place-items-center rounded-sm bg-muted">
+                  <Users className="size-3 text-foreground" />
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm">
+                  <span className="text-green-700 dark:text-green-300">+12.5%</span>
+                  <span className="text-muted-foreground"> vs last month</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="h-full rounded-none border-0 border-border border-b ring-0">
+              <CardHeader>
+                <CardTitle className="font-normal text-sm">Average Order</CardTitle>
+                <CardDescription className="text-3xl text-foreground tabular-nums leading-none tracking-tight">
+                  $128
+                </CardDescription>
+                <CardAction className="grid size-6 place-items-center rounded-sm bg-muted">
+                  <ReceiptText className="size-3 text-foreground" />
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm">
+                  <span className="text-destructive">-$4.20</span>
+                  <span className="text-muted-foreground"> vs last week</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="h-full rounded-none border-0 border-border border-b ring-0 md:border-r md:border-b-0">
+              <CardHeader>
+                <CardTitle className="font-normal text-sm">Return Requests</CardTitle>
+                <CardDescription className="text-3xl text-foreground tabular-nums leading-none tracking-tight">
+                  18
+                </CardDescription>
+                <CardAction className="grid size-6 place-items-center rounded-sm bg-muted">
+                  <RotateCcw className="size-3 text-foreground" />
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm">
+                  <span className="text-destructive">+0.6%</span>
+                  <span className="text-muted-foreground"> vs last month</span>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="h-full rounded-none border-0 ring-0">
+              <CardHeader>
+                <CardTitle className="font-normal text-sm">Stock Accuracy</CardTitle>
+                <CardDescription className="text-3xl text-foreground tabular-nums leading-none tracking-tight">
+                  97%
+                </CardDescription>
+                <CardAction className="grid size-6 place-items-center rounded-sm bg-muted">
+                  <PackageCheck className="size-3 text-foreground" />
+                </CardAction>
+              </CardHeader>
+              <CardContent>
+                <div className="text-sm">
+                  <span className="text-green-700 dark:text-green-300">+2.4 pts</span>
+                  <span className="text-muted-foreground"> vs last audit</span>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card className="h-full rounded-none border-0 ring-0 xl:col-span-7">
+            <CardHeader>
+              <CardTitle className="font-normal">Sales Overview</CardTitle>
+              <CardAction>
+                <ArrowUpRight className="size-4" />
+              </CardAction>
+            </CardHeader>
+
+            <CardContent>
+              <ChartContainer config={revenueOverviewConfig} className="h-72 w-full">
+                <ComposedChart
+                  accessibilityLayer
+                  data={revenueOverviewData}
+                  margin={{ bottom: 0, left: 0, right: 0, top: 0 }}
+                >
+                  <defs>
+                    <filter id="sales-line-glow" x="-20%" y="-20%" width="140%" height="140%">
+                      <feGaussianBlur stdDeviation="4" result="blur" />
+                      <feFlood floodColor="var(--color-revenue)" floodOpacity="0.35" />
+                      <feComposite in2="blur" operator="in" />
+                      <feMerge>
+                        <feMergeNode />
+                        <feMergeNode in="SourceGraphic" />
+                      </feMerge>
+                    </filter>
+                  </defs>
+                  <CartesianGrid xAxisId="revenue" yAxisId="profit" vertical={false} />
+                  <XAxis
+                    dataKey="period"
+                    axisLine={false}
+                    height={30}
+                    interval={0}
+                    minTickGap={0}
+                    tick={{ fontSize: 10 }}
+                    tickLine={false}
+                    tickMargin={8}
+                    tickFormatter={(value) => formatMonthTick(String(value))}
+                  />
+                  <YAxis yAxisId="revenue" hide domain={[3000, 10_000]} />
+                  <YAxis yAxisId="profit" hide domain={[0, 6000]} />
+                  <ChartTooltip
+                    content={<ChartTooltipContent labelFormatter={(value) => formatTooltipLabel(String(value))} />}
+                    cursor={{
+                      stroke: "var(--border)",
+                      strokeDasharray: "4 4",
+                    }}
+                  />
+                  <Bar
+                    yAxisId="profit"
+                    barSize={4}
+                    dataKey="profit"
+                    fill="var(--color-profit)"
+                    name="Profit"
+                    opacity={0.18}
+                    radius={[6, 6, 0, 0]}
+                  />
+                  <Area
+                    yAxisId="revenue"
+                    dataKey="revenue"
+                    fill="none"
+                    filter="url(#sales-line-glow)"
+                    stroke="var(--color-revenue)"
+                    strokeWidth={1.8}
+                    type="linear"
+                    activeDot={{
+                      r: 4,
+                      fill: "var(--background)",
+                      stroke: "var(--color-revenue)",
+                      strokeWidth: 2,
+                    }}
+                    dot={false}
+                  />
+                </ComposedChart>
+              </ChartContainer>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/columns.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/columns.tsx
@@ -1,0 +1,194 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { format, parseISO } from "date-fns";
+import { MoreHorizontal } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import type { OrderRow } from "./schema";
+
+function formatOrderDate(date: string) {
+  return format(parseISO(date), "h:mm a, d MMM yyyy");
+}
+
+function PaymentBadge({ status }: { status: OrderRow["payment"] }) {
+  if (status === "Paid") {
+    return (
+      <Badge
+        className="border-green-700/25 text-green-700 dark:border-green-300/25 dark:text-green-300"
+        variant="outline"
+      >
+        <span className="size-1.5 rounded-full bg-current" />
+        Paid
+      </Badge>
+    );
+  }
+
+  if (status === "Refunded") {
+    return (
+      <Badge variant="destructive">
+        <span className="size-1.5 rounded-full bg-current" />
+        Refunded
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge
+      className="border-yellow-700/25 text-yellow-700 dark:border-yellow-300/25 dark:text-yellow-300"
+      variant="outline"
+    >
+      <span className="size-1.5 rounded-full bg-current" />
+      Pending
+    </Badge>
+  );
+}
+
+function FulfillmentBadge({ status }: { status: OrderRow["fulfillment"] }) {
+  if (status === "Fulfilled") {
+    return (
+      <Badge
+        className="border-green-700/25 text-green-700 dark:border-green-300/25 dark:text-green-300"
+        variant="outline"
+      >
+        <span className="size-1.5 rounded-full bg-current" />
+        Fulfilled
+      </Badge>
+    );
+  }
+
+  if (status === "Returned") {
+    return (
+      <Badge variant="destructive">
+        <span className="size-1.5 rounded-full bg-current" />
+        Returned
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="destructive">
+      <span className="size-1.5 rounded-full bg-current" />
+      Unfulfilled
+    </Badge>
+  );
+}
+
+export const recentOrdersColumns: ColumnDef<OrderRow>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <div className="w-10">
+        <Checkbox
+          aria-label="Select all orders"
+          checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
+          onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        />
+      </div>
+    ),
+    cell: ({ row }) => (
+      <div className="w-10">
+        <Checkbox
+          aria-label={`Select order ${row.original.id}`}
+          checked={row.getIsSelected()}
+          onCheckedChange={(value) => row.toggleSelected(!!value)}
+        />
+      </div>
+    ),
+    enableHiding: false,
+    enableSorting: false,
+  },
+  {
+    accessorKey: "id",
+    header: "Order",
+    cell: ({ row }) => (
+      <div className="flex flex-col gap-0.5">
+        <div className="font-medium leading-none">{row.original.id}</div>
+        <div className="text-muted-foreground text-xs">{row.original.items}</div>
+      </div>
+    ),
+    enableHiding: false,
+  },
+  {
+    accessorKey: "customer",
+    header: "Customer",
+  },
+  {
+    id: "statusSummary",
+    header: "Status",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-2">
+        <PaymentBadge status={row.original.payment} />
+        <FulfillmentBadge status={row.original.fulfillment} />
+      </div>
+    ),
+    filterFn: (row, _columnId, value) => {
+      if (value === "Needs action") {
+        return (
+          row.original.payment === "Pending" ||
+          row.original.payment === "Refunded" ||
+          row.original.fulfillment === "Unfulfilled" ||
+          row.original.fulfillment === "Returned"
+        );
+      }
+
+      if (value === "Unfulfilled") {
+        return row.original.fulfillment === "Unfulfilled";
+      }
+
+      if (value === "Unpaid") {
+        return row.original.payment === "Pending";
+      }
+
+      if (value === "Returns") {
+        return row.original.payment === "Refunded" || row.original.fulfillment === "Returned";
+      }
+
+      return true;
+    },
+  },
+  {
+    accessorKey: "total",
+    header: () => <div className="w-28">Total</div>,
+    cell: ({ row }) => <div className="w-28 tabular-nums">{row.original.total}</div>,
+  },
+  {
+    accessorKey: "date",
+    header: () => <div className="w-44">Date</div>,
+    cell: ({ row }) => <div className="w-44 text-muted-foreground">{formatOrderDate(row.original.date)}</div>,
+  },
+  {
+    id: "actions",
+    header: () => <div className="flex w-full justify-end">Actions</div>,
+    cell: () => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div className="flex w-full justify-end">
+            <Button aria-label="Open order actions" size="icon-sm" variant="ghost">
+              <MoreHorizontal />
+            </Button>
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-40">
+          <DropdownMenuLabel>Order Actions</DropdownMenuLabel>
+          <DropdownMenuGroup>
+            <DropdownMenuItem>View order</DropdownMenuItem>
+            <DropdownMenuItem>Contact customer</DropdownMenuItem>
+            <DropdownMenuItem>Copy order ID</DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+    enableHiding: false,
+    enableSorting: false,
+  },
+];

--- a/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/data.json
+++ b/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/data.json
@@ -1,0 +1,308 @@
+[
+  {
+    "id": "#14550",
+    "date": "2026-05-09T16:42:00",
+    "customer": "Emma Smith",
+    "payment": "Pending",
+    "total": "$248.00",
+    "items": "2 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14536",
+    "date": "2026-05-09T14:18:00",
+    "customer": "Melody Macy",
+    "payment": "Paid",
+    "total": "$1,200.00",
+    "items": "3 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14521",
+    "date": "2026-05-08T21:05:00",
+    "customer": "Max Smith",
+    "payment": "Pending",
+    "total": "$79.00",
+    "items": "1 item",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14508",
+    "date": "2026-05-08T18:36:00",
+    "customer": "Sean Bean",
+    "payment": "Paid",
+    "total": "$5,500.00",
+    "items": "5 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14492",
+    "date": "2026-05-07T19:50:00",
+    "customer": "Brian Cox",
+    "payment": "Refunded",
+    "total": "$880.00",
+    "items": "2 items",
+    "fulfillment": "Returned"
+  },
+  {
+    "id": "#14477",
+    "date": "2026-05-07T13:24:00",
+    "customer": "Mikaela Collins",
+    "payment": "Paid",
+    "total": "$7,650.00",
+    "items": "4 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14463",
+    "date": "2026-05-06T22:11:00",
+    "customer": "Francis Mitcham",
+    "payment": "Pending",
+    "total": "$375.00",
+    "items": "2 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14451",
+    "date": "2026-05-06T11:45:00",
+    "customer": "Olivia Wild",
+    "payment": "Paid",
+    "total": "$38.00",
+    "items": "3 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14438",
+    "date": "2026-05-05T20:06:00",
+    "customer": "Neil Owen",
+    "payment": "Paid",
+    "total": "$76.00",
+    "items": "1 item",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14426",
+    "date": "2026-05-05T15:32:00",
+    "customer": "Dan Wilson",
+    "payment": "Refunded",
+    "total": "$204.00",
+    "items": "2 items",
+    "fulfillment": "Returned"
+  },
+  {
+    "id": "#14413",
+    "date": "2026-05-04T17:58:00",
+    "customer": "Emma Bold",
+    "payment": "Paid",
+    "total": "$31.00",
+    "items": "5 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14397",
+    "date": "2026-05-04T10:20:00",
+    "customer": "Ana Crown",
+    "payment": "Pending",
+    "total": "$52.00",
+    "items": "1 item",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14382",
+    "date": "2026-05-03T23:14:00",
+    "customer": "Robert Doe",
+    "payment": "Paid",
+    "total": "$350.00",
+    "items": "4 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14369",
+    "date": "2026-05-03T12:05:00",
+    "customer": "John Miller",
+    "payment": "Pending",
+    "total": "$501.00",
+    "items": "2 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14354",
+    "date": "2026-05-02T18:48:00",
+    "customer": "Lucy Kunic",
+    "payment": "Paid",
+    "total": "$415.00",
+    "items": "6 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14341",
+    "date": "2026-05-02T09:36:00",
+    "customer": "Ethan Wilder",
+    "payment": "Paid",
+    "total": "$298.00",
+    "items": "2 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14326",
+    "date": "2026-05-01T20:22:00",
+    "customer": "Karina Clark",
+    "payment": "Pending",
+    "total": "$487.00",
+    "items": "3 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14308",
+    "date": "2026-05-01T14:08:00",
+    "customer": "Olivia Bold",
+    "payment": "Paid",
+    "total": "$178.00",
+    "items": "4 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14295",
+    "date": "2026-04-30T19:31:00",
+    "customer": "Ana Clark",
+    "payment": "Refunded",
+    "total": "$193.00",
+    "items": "1 item",
+    "fulfillment": "Returned"
+  },
+  {
+    "id": "#14281",
+    "date": "2026-04-30T11:16:00",
+    "customer": "Nick Pitola",
+    "payment": "Paid",
+    "total": "$229.00",
+    "items": "3 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14266",
+    "date": "2026-04-29T21:40:00",
+    "customer": "Edward Kulnic",
+    "payment": "Pending",
+    "total": "$324.00",
+    "items": "2 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14249",
+    "date": "2026-04-29T13:55:00",
+    "customer": "Guy Hawkins",
+    "payment": "Paid",
+    "total": "$397.00",
+    "items": "2 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14234",
+    "date": "2026-04-28T18:09:00",
+    "customer": "Jane Cooper",
+    "payment": "Paid",
+    "total": "$424.00",
+    "items": "5 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14218",
+    "date": "2026-04-28T10:44:00",
+    "customer": "Esther Howard",
+    "payment": "Pending",
+    "total": "$313.00",
+    "items": "1 item",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14205",
+    "date": "2026-04-27T20:17:00",
+    "customer": "Jacob Jones",
+    "payment": "Paid",
+    "total": "$226.00",
+    "items": "3 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14186",
+    "date": "2026-04-27T12:28:00",
+    "customer": "Ralph Edwards",
+    "payment": "Paid",
+    "total": "$392.00",
+    "items": "4 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14172",
+    "date": "2026-04-26T17:46:00",
+    "customer": "Robert Fox",
+    "payment": "Refunded",
+    "total": "$683.00",
+    "items": "2 items",
+    "fulfillment": "Returned"
+  },
+  {
+    "id": "#14157",
+    "date": "2026-04-26T09:52:00",
+    "customer": "Cody Fisher",
+    "payment": "Paid",
+    "total": "$501.00",
+    "items": "7 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14143",
+    "date": "2026-04-25T22:03:00",
+    "customer": "Savannah Nguyen",
+    "payment": "Pending",
+    "total": "$138.00",
+    "items": "2 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14126",
+    "date": "2026-04-25T15:21:00",
+    "customer": "Brooklyn Simmons",
+    "payment": "Paid",
+    "total": "$143.00",
+    "items": "3 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14112",
+    "date": "2026-04-24T19:12:00",
+    "customer": "Cameron Williamson",
+    "payment": "Paid",
+    "total": "$202.00",
+    "items": "1 item",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14098",
+    "date": "2026-04-24T11:09:00",
+    "customer": "Albert Flores",
+    "payment": "Pending",
+    "total": "$209.00",
+    "items": "5 items",
+    "fulfillment": "Unfulfilled"
+  },
+  {
+    "id": "#14084",
+    "date": "2026-04-23T18:37:00",
+    "customer": "Jessie Clarkson",
+    "payment": "Paid",
+    "total": "$815.00",
+    "items": "3 items",
+    "fulfillment": "Fulfilled"
+  },
+  {
+    "id": "#14067",
+    "date": "2026-04-23T10:26:00",
+    "customer": "Jenny Wilson",
+    "payment": "Refunded",
+    "total": "$297.00",
+    "items": "1 item",
+    "fulfillment": "Returned"
+  }
+]

--- a/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/formatters.ts
+++ b/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/formatters.ts
@@ -1,0 +1,31 @@
+import type React from "react";
+
+import type { OrderFilter } from "./schema";
+
+export function formatOrderCount(filter: OrderFilter, count: number) {
+  const orderLabel = count === 1 ? "order" : "orders";
+
+  if (filter === "All") {
+    return `${count.toLocaleString()} ${orderLabel}`;
+  }
+
+  if (filter === "Needs action") {
+    return `${count.toLocaleString()} ${orderLabel} need action`;
+  }
+
+  if (filter === "Returns") {
+    return `${count.toLocaleString()} ${count === 1 ? "return" : "returns"}`;
+  }
+
+  return `${count.toLocaleString()} ${filter.toLowerCase()} ${orderLabel}`;
+}
+
+export function formatSelectedOrderCount(count: number) {
+  const orderLabel = count === 1 ? "order" : "orders";
+
+  return `${count.toLocaleString()} ${orderLabel} selected`;
+}
+
+export function preventPaginationNavigation(event: React.MouseEvent<HTMLAnchorElement>) {
+  event.preventDefault();
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/schema.ts
+++ b/src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/schema.ts
@@ -1,0 +1,13 @@
+export const orderFilters = ["All", "Needs action", "Unfulfilled", "Unpaid", "Returns"] as const;
+
+export type OrderFilter = (typeof orderFilters)[number];
+
+export type OrderRow = {
+  id: string;
+  date: string;
+  customer: string;
+  payment: "Paid" | "Pending" | "Refunded";
+  total: string;
+  items: string;
+  fulfillment: "Fulfilled" | "Returned" | "Unfulfilled";
+};

--- a/src/app/(main)/dashboard/ecommerce/_components/recent-orders.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/recent-orders.tsx
@@ -94,7 +94,7 @@ export function RecentOrders() {
     <Card>
       <CardHeader>
         <CardTitle className="font-normal text-muted-foreground text-sm">Recent Orders</CardTitle>
-        <CardDescription className="text-foreground text-xl capitalize tabular-nums leading-none tracking-tight">
+        <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">
           {orderCountDescription}
         </CardDescription>
         <CardAction className="flex items-center gap-1">

--- a/src/app/(main)/dashboard/ecommerce/_components/recent-orders.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/recent-orders.tsx
@@ -1,0 +1,233 @@
+"use client";
+"use no memo";
+
+import * as React from "react";
+
+import {
+  type ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type PaginationState,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowUpDown, ArrowUpRight, Download, MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+import { recentOrdersColumns } from "./recent-orders-table/columns";
+import recentOrdersData from "./recent-orders-table/data.json";
+import {
+  formatOrderCount,
+  formatSelectedOrderCount,
+  preventPaginationNavigation,
+} from "./recent-orders-table/formatters";
+import { type OrderFilter, type OrderRow, orderFilters } from "./recent-orders-table/schema";
+
+const recentOrders = recentOrdersData as OrderRow[];
+
+export function RecentOrders() {
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  const table = useReactTable({
+    data: recentOrders,
+    columns: recentOrdersColumns,
+    state: {
+      rowSelection,
+      sorting,
+      columnFilters,
+      pagination,
+    },
+    getRowId: (row) => row.id,
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const activeFilter = (table.getColumn("statusSummary")?.getFilterValue() as OrderFilter | undefined) ?? "All";
+  const orderCount = table.getFilteredRowModel().rows.length;
+  const selectedOrderCount = table.getSelectedRowModel().rows.length;
+  const visibleOrderCount = table.getRowModel().rows.length;
+  const currentPage = table.getState().pagination.pageIndex + 1;
+  const pageCount = table.getPageCount();
+  const orderCountDescription =
+    selectedOrderCount > 0 ? formatSelectedOrderCount(selectedOrderCount) : formatOrderCount(activeFilter, orderCount);
+  const pageNumbers = React.useMemo(() => {
+    if (pageCount <= 3) {
+      return Array.from({ length: pageCount }, (_, index) => index + 1);
+    }
+
+    if (currentPage <= 2) return [1, 2, 3];
+    if (currentPage >= pageCount - 1) return [pageCount - 2, pageCount - 1, pageCount];
+
+    return [currentPage - 1, currentPage, currentPage + 1];
+  }, [currentPage, pageCount]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="font-normal text-muted-foreground text-sm">Recent Orders</CardTitle>
+        <CardDescription className="text-foreground text-xl capitalize tabular-nums leading-none tracking-tight">
+          {orderCountDescription}
+        </CardDescription>
+        <CardAction className="flex items-center gap-1">
+          <Button aria-label="Open orders" size="icon-sm" variant="outline">
+            <ArrowUpRight />
+          </Button>
+          <Button aria-label="Download orders" size="icon-sm" variant="outline">
+            <Download />
+          </Button>
+          <Button size="icon-sm" variant="outline">
+            <MoreHorizontal />
+          </Button>
+        </CardAction>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4 px-0">
+        <div className="flex items-center justify-between px-4">
+          <ToggleGroup
+            className="bg-muted p-0.75 text-muted-foreground **:data-[slot=toggle-group-item]:rounded-md **:data-[slot=toggle-group-item]:border **:data-[slot=toggle-group-item]:border-transparent **:data-[slot=toggle-group-item]:text-foreground/60 **:data-[slot=toggle-group-item]:hover:text-foreground [&_[data-slot=toggle-group-item][data-state=on]]:bg-background [&_[data-slot=toggle-group-item][data-state=on]]:text-foreground [&_[data-slot=toggle-group-item][data-state=on]]:shadow-sm dark:[&_[data-slot=toggle-group-item][data-state=on]]:border-input dark:[&_[data-slot=toggle-group-item][data-state=on]]:bg-input/30"
+            onValueChange={(value) => {
+              if (!value) return;
+              table.getColumn("statusSummary")?.setFilterValue(value === "All" ? undefined : value);
+              table.setPageIndex(0);
+            }}
+            size="sm"
+            spacing={1}
+            type="single"
+            value={activeFilter}
+          >
+            {orderFilters.map((filter) => (
+              <ToggleGroupItem key={filter} value={filter}>
+                {filter}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+
+          <Button
+            size="icon-sm"
+            variant="outline"
+            onClick={() => table.getColumn("date")?.toggleSorting(table.getColumn("date")?.getIsSorted() === "asc")}
+          >
+            <ArrowUpDown />
+          </Button>
+        </div>
+
+        <div className="overflow-hidden">
+          <Table className="**:data-[slot='table-cell']:px-4.5 **:data-[slot='table-head']:px-4.5">
+            <TableHeader className="border-t **:data-[slot='table-head']:h-11 **:data-[slot='table-head']:font-normal **:data-[slot='table-head']:text-foreground **:data-[slot='table-head']:text-sm">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead key={header.id} colSpan={header.colSpan}>
+                      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody className="**:data-[slot='table-row']:border-border/50 **:data-[slot='table-cell']:px-4 **:data-[slot='table-cell']:py-3 **:data-[slot='table-row']:hover:bg-transparent">
+              {table.getRowModel().rows.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell className="h-24 text-center" colSpan={table.getVisibleLeafColumns().length}>
+                    No orders found.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 px-4 pb-1">
+          <p className="text-muted-foreground text-sm">
+            Viewing {visibleOrderCount} out of {orderCount.toLocaleString()} orders
+          </p>
+
+          <Pagination className="mx-0 w-auto justify-end">
+            <PaginationContent className="gap-1.5">
+              <PaginationItem>
+                <PaginationPrevious
+                  className={!table.getCanPreviousPage() ? "pointer-events-none opacity-50" : undefined}
+                  href="#"
+                  onClick={(event) => {
+                    preventPaginationNavigation(event);
+                    table.previousPage();
+                  }}
+                />
+              </PaginationItem>
+              {pageNumbers[0] > 1 ? (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              ) : null}
+              {pageNumbers.map((pageNumber) => (
+                <PaginationItem key={`page-${pageNumber}`}>
+                  <PaginationLink
+                    href="#"
+                    isActive={table.getState().pagination.pageIndex === pageNumber - 1}
+                    onClick={(event) => {
+                      preventPaginationNavigation(event);
+                      table.setPageIndex(pageNumber - 1);
+                    }}
+                  >
+                    {pageNumber}
+                  </PaginationLink>
+                </PaginationItem>
+              ))}
+              {pageNumbers[pageNumbers.length - 1] < pageCount ? (
+                <PaginationItem>
+                  <PaginationEllipsis />
+                </PaginationItem>
+              ) : null}
+              <PaginationItem>
+                <PaginationNext
+                  className={!table.getCanNextPage() ? "pointer-events-none opacity-50" : undefined}
+                  href="#"
+                  onClick={(event) => {
+                    preventPaginationNavigation(event);
+                    table.nextPage();
+                  }}
+                />
+              </PaginationItem>
+            </PaginationContent>
+          </Pagination>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { format, subMinutes } from "date-fns";
+import { ArrowUpRight } from "lucide-react";
+import { Area, AreaChart, CartesianGrid, Line, XAxis, YAxis } from "recharts";
+
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+const trafficIntervalMinutes = 15;
+
+const trafficPoints = [
+  { visitors: 280, anomalies: 8 },
+  { visitors: 420, anomalies: 4 },
+  { visitors: 360, anomalies: 3 },
+  { visitors: 140, anomalies: 2 },
+  { visitors: 80, anomalies: 1 },
+  { visitors: 600, anomalies: 4 },
+  { visitors: 260, anomalies: 3 },
+  { visitors: 70, anomalies: 2 },
+  { visitors: 90, anomalies: 1 },
+  { visitors: 180, anomalies: 4 },
+  { visitors: 150, anomalies: 3 },
+  { visitors: 60, anomalies: 2 },
+  { visitors: 430, anomalies: 1 },
+  { visitors: 110, anomalies: 4 },
+  { visitors: 260, anomalies: 3 },
+  { visitors: 120, anomalies: 2 },
+  { visitors: 90, anomalies: 1 },
+  { visitors: 40, anomalies: 8 },
+  { visitors: 75, anomalies: 3 },
+  { visitors: 0, anomalies: 2 },
+  { visitors: 15, anomalies: 1 },
+  { visitors: 35, anomalies: 4 },
+  { visitors: 60, anomalies: 3 },
+  { visitors: 95, anomalies: 2 },
+  { visitors: 105, anomalies: 1 },
+  { visitors: 120, anomalies: 4 },
+  { visitors: 0, anomalies: 3 },
+  { visitors: 25, anomalies: 2 },
+  { visitors: 70, anomalies: 1 },
+  { visitors: 110, anomalies: 4 },
+  { visitors: 0, anomalies: 3 },
+  { visitors: 140, anomalies: 2 },
+  { visitors: 310, anomalies: 1 },
+  { visitors: 120, anomalies: 4 },
+  { visitors: 160, anomalies: 8 },
+  { visitors: 30, anomalies: 2 },
+  { visitors: 20, anomalies: 1 },
+  { visitors: 0, anomalies: 4 },
+  { visitors: 120, anomalies: 3 },
+  { visitors: 210, anomalies: 2 },
+  { visitors: 110, anomalies: 1 },
+  { visitors: 190, anomalies: 4 },
+  { visitors: 0, anomalies: 3 },
+  { visitors: 85, anomalies: 2 },
+  { visitors: 250, anomalies: 1 },
+  { visitors: 40, anomalies: 4 },
+  { visitors: 110, anomalies: 3 },
+  { visitors: 0, anomalies: 2 },
+  { visitors: 140, anomalies: 1 },
+  { visitors: 95, anomalies: 4 },
+  { visitors: 180, anomalies: 3 },
+  { visitors: 620, anomalies: 18 },
+  { visitors: 35, anomalies: 1 },
+  { visitors: 330, anomalies: 4 },
+  { visitors: 45, anomalies: 3 },
+  { visitors: 0, anomalies: 2 },
+  { visitors: 160, anomalies: 1 },
+  { visitors: 190, anomalies: 4 },
+  { visitors: 260, anomalies: 3 },
+  { visitors: 90, anomalies: 2 },
+  { visitors: 70, anomalies: 1 },
+  { visitors: 180, anomalies: 4 },
+  { visitors: 150, anomalies: 3 },
+  { visitors: 280, anomalies: 2 },
+  { visitors: 160, anomalies: 1 },
+  { visitors: 20, anomalies: 4 },
+  { visitors: 120, anomalies: 3 },
+  { visitors: 200, anomalies: 2 },
+  { visitors: 45, anomalies: 8 },
+  { visitors: 115, anomalies: 4 },
+  { visitors: 145, anomalies: 3 },
+  { visitors: 40, anomalies: 2 },
+  { visitors: 160, anomalies: 1 },
+  { visitors: 170, anomalies: 4 },
+  { visitors: 95, anomalies: 3 },
+  { visitors: 140, anomalies: 2 },
+  { visitors: 70, anomalies: 1 },
+  { visitors: 230, anomalies: 4 },
+  { visitors: 120, anomalies: 3 },
+  { visitors: 65, anomalies: 2 },
+  { visitors: 35, anomalies: 1 },
+  { visitors: 0, anomalies: 4 },
+  { visitors: 80, anomalies: 3 },
+  { visitors: 180, anomalies: 2 },
+  { visitors: 95, anomalies: 1 },
+  { visitors: 140, anomalies: 8 },
+  { visitors: 270, anomalies: 3 },
+  { visitors: 110, anomalies: 2 },
+  { visitors: 50, anomalies: 1 },
+  { visitors: 230, anomalies: 18 },
+  { visitors: 115, anomalies: 3 },
+  { visitors: 80, anomalies: 2 },
+  { visitors: 260, anomalies: 1 },
+  { visitors: 20, anomalies: 4 },
+  { visitors: 120, anomalies: 3 },
+  { visitors: 5, anomalies: 2 },
+] as const;
+
+function getTrafficData() {
+  const now = new Date();
+
+  return trafficPoints.map((point, index) => ({
+    ...point,
+    timestamp: subMinutes(now, (trafficPoints.length - 1 - index) * trafficIntervalMinutes).toISOString(),
+  }));
+}
+
+const trafficConfig = {
+  visitors: {
+    label: "Visitors",
+    color: "var(--chart-3)",
+  },
+  anomalies: {
+    label: "Anomalies",
+    color: "var(--destructive)",
+  },
+} satisfies ChartConfig;
+
+function formatTrafficTooltipLabel(value: string) {
+  return format(new Date(value), "h:mm a, do MMMM yyyy");
+}
+
+export function StoreTraffic() {
+  const trafficData = useMemo(getTrafficData, []);
+  const firstTrafficTimestamp = trafficData[0].timestamp;
+  const lastTrafficTimestamp = trafficData.at(-1)?.timestamp ?? "";
+
+  function formatTrafficTick(value: string) {
+    if (value === firstTrafficTimestamp) {
+      return "24h ago";
+    }
+
+    return value === lastTrafficTimestamp ? "now" : "";
+  }
+
+  return (
+    <Card className="xl:col-span-7">
+      <CardHeader>
+        <CardTitle className="font-normal text-muted-foreground text-sm">Store Traffic</CardTitle>
+        <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">
+          12.9K visits
+        </CardDescription>
+        <CardAction>
+          <ArrowUpRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+
+      <CardContent>
+        <ChartContainer config={trafficConfig} className="h-54 w-full">
+          <AreaChart accessibilityLayer data={trafficData} margin={{ bottom: 0, left: 0, right: 0, top: 8 }}>
+            <defs>
+              <linearGradient id="fillVisitors" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="5%" stopColor="var(--color-visitors)" stopOpacity={0.28} />
+                <stop offset="95%" stopColor="var(--color-visitors)" stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              axisLine={false}
+              dataKey="timestamp"
+              tick={{ fontSize: 11 }}
+              tickFormatter={formatTrafficTick}
+              tickLine={false}
+              tickMargin={10}
+              ticks={[trafficData[0].timestamp, trafficData.at(-1)?.timestamp ?? ""]}
+            />
+            <YAxis axisLine={false} domain={[0, 650]} tickLine={false} tickMargin={6} width={36} yAxisId="traffic" />
+            <ChartTooltip
+              content={<ChartTooltipContent labelFormatter={(value) => formatTrafficTooltipLabel(String(value))} />}
+              cursor={{ stroke: "var(--border)", strokeDasharray: "4 4" }}
+            />
+            <ChartLegend align="right" verticalAlign="top" className="justify-end" content={<ChartLegendContent />} />
+            <Area
+              dataKey="visitors"
+              dot={false}
+              fill="url(#fillVisitors)"
+              stroke="var(--color-visitors)"
+              strokeWidth={2}
+              type="stepAfter"
+              yAxisId="traffic"
+            />
+            <Line
+              dataKey="anomalies"
+              dot={false}
+              stroke="var(--color-anomalies)"
+              strokeLinecap="round"
+              strokeWidth={1.2}
+              type="stepAfter"
+              yAxisId="traffic"
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx
@@ -155,7 +155,7 @@ export function StoreTraffic() {
   }
 
   return (
-    <Card className="xl:col-span-7">
+    <Card>
       <CardHeader>
         <CardTitle className="font-normal text-muted-foreground text-sm">Store Traffic</CardTitle>
         <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">

--- a/src/app/(main)/dashboard/ecommerce/_components/top-products.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/top-products.tsx
@@ -1,0 +1,105 @@
+import { ArrowUpRight } from "lucide-react";
+
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+
+const categories = [
+  {
+    name: "Apparel",
+    share: 44,
+    color: "var(--chart-3)",
+  },
+  {
+    name: "Accessories",
+    share: 32,
+    color: "var(--chart-2)",
+  },
+  {
+    name: "Home",
+    share: 24,
+    color: "var(--chart-1)",
+  },
+] as const;
+
+const products = [
+  {
+    name: "Linen Overshirt",
+    category: "Apparel",
+    share: "31%",
+    sales: "$14,820",
+  },
+  {
+    name: "Everyday Tote",
+    category: "Accessories",
+    share: "24%",
+    sales: "$11,460",
+  },
+  {
+    name: "Ceramic Planter",
+    category: "Home",
+    share: "18%",
+    sales: "$8,930",
+  },
+] as const;
+
+export function TopProducts() {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="font-normal text-muted-foreground text-sm">Top Products</CardTitle>
+        <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">
+          73% of sales
+        </CardDescription>
+        <CardAction>
+          <ArrowUpRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <div aria-label="Sales by category" className="flex h-2 gap-1 overflow-hidden bg-muted" role="img">
+            {categories.map((category) => (
+              <div
+                aria-hidden="true"
+                key={category.name}
+                className="rounded-md"
+                style={{
+                  backgroundColor: category.color,
+                  width: `${category.share}%`,
+                }}
+              />
+            ))}
+          </div>
+
+          <div className="flex flex-wrap gap-4">
+            {categories.map((category) => (
+              <div className="flex items-center gap-1" key={category.name}>
+                <span aria-hidden="true" className="size-2 rounded-full" style={{ backgroundColor: category.color }} />
+                <span className="text-muted-foreground text-xs">{category.name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <Separator />
+
+        <div className="grid grid-cols-[1fr_auto_auto] gap-x-4 gap-y-3">
+          <div className="text-muted-foreground text-xs">Products</div>
+          <div className="text-muted-foreground text-xs">Share</div>
+          <div className="text-muted-foreground text-xs">Sales</div>
+
+          {products.map((product) => (
+            <div className="contents text-sm" key={product.name}>
+              <div className="min-w-0">
+                <div className="truncate font-medium">{product.name}</div>
+                <div className="text-muted-foreground text-xs">{product.category}</div>
+              </div>
+              <div className="self-center text-muted-foreground tabular-nums">{product.share}</div>
+              <div className="self-center font-medium tabular-nums">{product.sales}</div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/_components/traffic-sources.tsx
+++ b/src/app/(main)/dashboard/ecommerce/_components/traffic-sources.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { ArrowUpRight } from "lucide-react";
+import { Bar, BarChart, LabelList, type LabelProps, XAxis, YAxis } from "recharts";
+import { siEbay, siGoogle, siMeta, siShopify, siTiktok } from "simple-icons";
+
+import { SimpleIcon } from "@/components/simple-icon";
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+
+const trafficSources = [
+  {
+    name: "Meta",
+    visits: "5,640",
+    share: 38,
+    change: "+18%",
+    icon: siMeta,
+  },
+  {
+    name: "Google",
+    visits: "3,740",
+    share: 25,
+    change: "-6%",
+    icon: siGoogle,
+  },
+  {
+    name: "Shopify",
+    visits: "2,960",
+    share: 20,
+    change: "+7%",
+    icon: siShopify,
+  },
+  {
+    name: "TikTok",
+    visits: "1,340",
+    share: 10,
+    change: "+9%",
+    icon: siTiktok,
+  },
+  {
+    name: "eBay",
+    visits: "1,080",
+    share: 7,
+    change: "-3%",
+    icon: siEbay,
+  },
+] as const;
+
+const trafficSourcesConfig = {
+  share: {
+    label: "Visits",
+    color: "var(--chart-1)",
+  },
+} satisfies ChartConfig;
+
+type IconLabelProps = {
+  height?: number | string;
+  index?: number;
+  width?: number | string;
+  x?: number | string;
+  y?: number | string;
+};
+
+type SourceLabelProps = LabelProps & {
+  index?: number;
+  value?: number | string;
+};
+
+function getNumber(value: number | string | undefined) {
+  return typeof value === "number" ? value : Number(value);
+}
+
+function TrafficSourceIconLabel({ height, index, width, x, y }: IconLabelProps) {
+  if (typeof index !== "number") {
+    return null;
+  }
+
+  const source = trafficSources[index];
+  const xValue = getNumber(x);
+  const yValue = getNumber(y);
+  const widthValue = getNumber(width);
+  const heightValue = getNumber(height);
+
+  if (
+    !source ||
+    Number.isNaN(xValue) ||
+    Number.isNaN(yValue) ||
+    Number.isNaN(widthValue) ||
+    Number.isNaN(heightValue)
+  ) {
+    return null;
+  }
+
+  const iconSize = 16;
+  const iconX = Math.max(xValue + 10, xValue + widthValue - iconSize - 10);
+  const iconY = yValue + (heightValue - iconSize) / 2;
+
+  return (
+    <foreignObject height={iconSize} x={iconX} y={iconY} width={iconSize}>
+      <SimpleIcon icon={source.icon} className="size-4 fill-foreground" />
+    </foreignObject>
+  );
+}
+
+function TrafficSourceNameLabel({ height, index, x, y }: SourceLabelProps) {
+  if (typeof index !== "number") {
+    return null;
+  }
+
+  const source = trafficSources[index];
+  const xValue = getNumber(x);
+  const yValue = getNumber(y);
+  const heightValue = getNumber(height);
+
+  if (!source || Number.isNaN(xValue) || Number.isNaN(yValue) || Number.isNaN(heightValue)) {
+    return null;
+  }
+
+  return (
+    <text dominantBaseline="middle" textAnchor="start" x={2} y={yValue + heightValue / 2}>
+      <tspan className="fill-foreground font-medium" fontSize={13} x={2} y={yValue + heightValue / 2 - 7}>
+        {source.name}
+      </tspan>
+      <tspan className="fill-muted-foreground" fontSize={12} x={2} y={yValue + heightValue / 2 + 11}>
+        {source.visits}
+      </tspan>
+    </text>
+  );
+}
+
+function TrafficSourceChangeLabel({ height, value, y }: SourceLabelProps) {
+  const yValue = getNumber(y);
+  const heightValue = getNumber(height);
+
+  if (typeof value !== "string" || Number.isNaN(yValue) || Number.isNaN(heightValue)) {
+    return null;
+  }
+
+  const isNegative = value.startsWith("-");
+
+  return (
+    <text
+      className={isNegative ? "fill-destructive" : "fill-green-700 dark:fill-green-300"}
+      dominantBaseline="middle"
+      dx={-6}
+      fontSize={13}
+      textAnchor="end"
+      x="100%"
+      y={yValue + heightValue / 2}
+    >
+      {value}
+    </text>
+  );
+}
+
+export function TrafficSources() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="font-normal text-muted-foreground text-sm">Traffic Sources</CardTitle>
+        <CardDescription className="text-foreground text-xl tabular-nums leading-none tracking-tight">
+          14.8K visits
+        </CardDescription>
+        <CardAction>
+          <ArrowUpRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+
+      <CardContent>
+        <ChartContainer config={trafficSourcesConfig} className="h-54 w-full">
+          <BarChart
+            accessibilityLayer
+            barCategoryGap={12}
+            data={trafficSources}
+            layout="vertical"
+            margin={{ bottom: 0, left: 100, right: 50, top: 0 }}
+          >
+            <defs>
+              <pattern
+                height="4"
+                id="ecommerce-traffic-source-background-pattern"
+                patternTransform="rotate(45)"
+                patternUnits="userSpaceOnUse"
+                width="4"
+              >
+                <rect height="6" width="6" fill="var(--muted)" fillOpacity="0.5" />
+                <line
+                  stroke="var(--muted-foreground)"
+                  strokeOpacity="0.10"
+                  strokeWidth="1.25"
+                  x1="0"
+                  x2="0"
+                  y1="0"
+                  y2="6"
+                />
+              </pattern>
+            </defs>
+            <XAxis dataKey="share" domain={[0, 100]} hide type="number" />
+            <YAxis dataKey="name" hide type="category" />
+            <Bar
+              background={{ fill: "url(#ecommerce-traffic-source-background-pattern)", radius: 8 }}
+              barSize={36}
+              dataKey="share"
+              fill="var(--color-share)"
+              fillOpacity={0.5}
+              name="Visits"
+              radius={8}
+              stroke="var(--color-share)"
+              strokeOpacity={0.1}
+              strokeWidth={0.5}
+            >
+              <LabelList content={<TrafficSourceNameLabel />} dataKey="name" />
+              <LabelList content={<TrafficSourceIconLabel />} dataKey="share" />
+              <LabelList content={<TrafficSourceChangeLabel />} dataKey="change" />
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { Separator } from "@/components/ui/separator";
 
 import { KpiStrip } from "./_components/kpi-strip";
+import { RecentOrders } from "./_components/recent-orders";
 import { StoreTraffic } from "./_components/store-traffic";
 import { TrafficSources } from "./_components/traffic-sources";
 
@@ -65,6 +66,9 @@ export default function Page() {
         </div>
         <div className="xl:col-span-7">
           <TrafficSources />
+        </div>
+        <div className="xl:col-span-12">
+          <RecentOrders />
         </div>
       </div>
     </div>

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -7,6 +7,7 @@ import { Separator } from "@/components/ui/separator";
 
 import { KpiStrip } from "./_components/kpi-strip";
 import { StoreTraffic } from "./_components/store-traffic";
+import { TrafficSources } from "./_components/traffic-sources";
 
 export default function Page() {
   const formattedDate = format(new Date(), "EEEE, do MMMM yyyy");
@@ -61,6 +62,9 @@ export default function Page() {
         <KpiStrip />
         <div className="xl:col-span-5">
           <StoreTraffic />
+        </div>
+        <div className="xl:col-span-7">
+          <TrafficSources />
         </div>
       </div>
     </div>

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -5,9 +5,12 @@ import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 
+import { CustomerReviews } from "./_components/customer-reviews";
+import { Inventory } from "./_components/inventory";
 import { KpiStrip } from "./_components/kpi-strip";
 import { RecentOrders } from "./_components/recent-orders";
 import { StoreTraffic } from "./_components/store-traffic";
+import { TopProducts } from "./_components/top-products";
 import { TrafficSources } from "./_components/traffic-sources";
 
 export default function Page() {
@@ -66,6 +69,15 @@ export default function Page() {
         </div>
         <div className="xl:col-span-7">
           <TrafficSources />
+        </div>
+        <div className="xl:col-span-4">
+          <TopProducts />
+        </div>
+        <div className="xl:col-span-4">
+          <Inventory />
+        </div>
+        <div className="xl:col-span-4">
+          <CustomerReviews />
         </div>
         <div className="xl:col-span-12">
           <RecentOrders />

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -1,4 +1,9 @@
 import { format } from "date-fns";
+import { Settings2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 
 import { KpiStrip } from "./_components/kpi-strip";
 
@@ -7,9 +12,48 @@ export default function Page() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="space-y-1">
-        <h1 className="text-3xl leading-none tracking-tight">Store Overview</h1>
-        <p className="text-muted-foreground text-sm">{formattedDate}</p>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-3xl leading-none tracking-tight">Store Overview</h1>
+          <p className="text-muted-foreground text-sm">{formattedDate}</p>
+        </div>
+
+        <div className="flex flex-wrap items-end justify-end gap-2 lg:w-fit">
+          <Select defaultValue="this-month">
+            <SelectTrigger className="w-34" id="ecommerce-period" size="sm">
+              <SelectValue placeholder="This Month" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="this-month">This Month</SelectItem>
+                <SelectItem value="last-month">Last Month</SelectItem>
+                <SelectItem value="last-30-days">Last 30 Days</SelectItem>
+                <SelectItem value="year-to-date">Year to Date</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+
+          <Select defaultValue="all-channels">
+            <SelectTrigger className="w-40" id="ecommerce-channel" size="sm">
+              <SelectValue placeholder="All Channels" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectItem value="all-channels">All Channels</SelectItem>
+                <SelectItem value="online-store">Online Store</SelectItem>
+                <SelectItem value="marketplace">Marketplace</SelectItem>
+                <SelectItem value="social">Social</SelectItem>
+                <SelectItem value="retail">Retail</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+
+          <Separator orientation="vertical" />
+
+          <Button size="icon-sm" variant="outline">
+            <Settings2 />
+          </Button>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -59,7 +59,9 @@ export default function Page() {
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
         <KpiStrip />
-        <StoreTraffic />
+        <div className="xl:col-span-5">
+          <StoreTraffic />
+        </div>
       </div>
     </div>
   );

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -1,0 +1,20 @@
+import { format } from "date-fns";
+
+import { KpiStrip } from "./_components/kpi-strip";
+
+export default function Page() {
+  const formattedDate = format(new Date(), "EEEE, do MMMM yyyy");
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="space-y-1">
+        <h1 className="text-3xl leading-none tracking-tight">Store Overview</h1>
+        <p className="text-muted-foreground text-sm">{formattedDate}</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <KpiStrip />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/ecommerce/page.tsx
+++ b/src/app/(main)/dashboard/ecommerce/page.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectVa
 import { Separator } from "@/components/ui/separator";
 
 import { KpiStrip } from "./_components/kpi-strip";
+import { StoreTraffic } from "./_components/store-traffic";
 
 export default function Page() {
   const formattedDate = format(new Date(), "EEEE, do MMMM yyyy");
@@ -58,6 +59,7 @@ export default function Page() {
 
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
         <KpiStrip />
+        <StoreTraffic />
       </div>
     </div>
   );

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -76,9 +76,8 @@ export const sidebarItems: NavGroup[] = [
       },
       {
         title: "E-commerce",
-        url: "/dashboard/coming-soon",
+        url: "/dashboard/ecommerce",
         icon: ShoppingBag,
-        comingSoon: true,
       },
       {
         title: "Academy",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the ecommerce dashboard page, wiring up a fully-featured set of widgets — KPI strip, store-traffic chart, traffic-sources bar chart, top-products breakdown, inventory gauge, customer-reviews card, and a paginated/filterable recent-orders table — and updates the sidebar entry from "coming soon" to the live route.

- **KPI Strip & Sales Overview** (`kpi-strip.tsx`): Six KPI cards plus a `ComposedChart` combining a revenue `Area` and profit `Bar`; the tooltip date-clamping fix (`Math.min(end, lastDayOfMonth)`) is present in this version, addressing the prior month-overflow concern.
- **Recent Orders table** (`recent-orders.tsx` + sub-files): Client-side TanStack Table with five filter tabs, date sorting, and a three-page-number sliding paginator — logic for edge pages and ellipsis display is correct.
- **Store Traffic** (`store-traffic.tsx`): The anomalies `Line` still shares `yAxisId="traffic"` (domain 0–650) with the visitors `Area`, making anomaly values (1–18) render as a near-flat line at the chart floor — a concern noted in the prior outside-diff comment that remains unaddressed.

<h3>Confidence Score: 4/5</h3>

Safe to merge with awareness that the anomalies line in Store Traffic remains visually ineffective and the page date header will freeze at build time without force-dynamic.

The ecommerce page renders new Date() inside a Server Component with no dynamic export, so the "today" heading will show the build/deploy date to every visitor. The StoreTraffic chart's anomalies series — drawn in the destructive/red color to signal importance — shares a Y-axis scaled for visitor counts (0–650), leaving anomaly values of 1–18 occupying only ~3% of the chart height and appearing as a nearly invisible flat line. Both issues remain in the final code after prior review comments flagged them.

src/app/(main)/dashboard/ecommerce/page.tsx (static date) and src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx (anomalies axis scale)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/(main)/dashboard/ecommerce/page.tsx | Main page composing all dashboard widgets; uses new Date() at render time in a statically-rendered Server Component, causing a stale date heading (flagged in prior review). |
| src/app/(main)/dashboard/ecommerce/_components/kpi-strip.tsx | KPI strip with six metric cards and a Sales Overview ComposedChart; CartesianGrid yAxisId/xAxisId mismatches flagged in prior review; tooltip date-clamp fix is now present in this version. |
| src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx | Visitor/anomaly AreaChart; anomalies Line shares the visitors YAxis (domain 0–650) making anomaly values (1–18) nearly invisible — active unfixed issue from prior review. |
| src/app/(main)/dashboard/ecommerce/_components/recent-orders.tsx | Full-featured TanStack Table with client-side filtering, sorting, and pagination; logic is sound; minor: the "more" icon button in the card header is missing an aria-label. |
| src/app/(main)/dashboard/ecommerce/_components/recent-orders-table/columns.tsx | Column definitions with badge renderers and a custom statusSummary filterFn; logic correctly maps "Unpaid" to Pending payment and "Returns" to Refunded/Returned rows. |
| src/app/(main)/dashboard/ecommerce/_components/traffic-sources.tsx | Horizontal BarChart with custom SVG label components for name, icon, and percentage change; positioning math is guarded against NaN values. |
| src/app/(main)/dashboard/ecommerce/_components/inventory.tsx | Semicircle gauge PieChart built from dynamically-segmented array; percentage computations and label rendering are correct for the static data. |
| src/app/(main)/dashboard/ecommerce/_components/customer-reviews.tsx | Static review card with accessible avatar group; prev/next navigation buttons render with aria-labels but have no onClick handlers — intentional given static demo data. |
| src/app/(main)/dashboard/ecommerce/_components/top-products.tsx | Static stacked-bar legend and product grid; category percentages sum to 100%, consistent with the header subtitle. |
| src/navigation/sidebar/sidebar-items.ts | E-commerce nav entry updated from /dashboard/coming-soon to /dashboard/ecommerce and comingSoon flag removed. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    page["page.tsx\nStore Overview"]
    kpi["KpiStrip\n6 KPI cards + Sales Overview\nComposedChart (Area + Bar)"]
    traffic["StoreTraffic\nAreaChart\nvisitors + anomalies"]
    sources["TrafficSources\nHorizontal BarChart\nMeta/Google/Shopify/TikTok/eBay"]
    top["TopProducts\nStacked bar + product grid"]
    inv["Inventory\nSemiCircle PieChart gauge"]
    reviews["CustomerReviews\nStatic review card"]
    orders["RecentOrders\nTanStack Table\nfilter · sort · paginate"]
    data["data.json\n35 mock orders"]
    schema["schema.ts\nOrderRow type\nOrderFilter union"]
    cols["columns.tsx\nColumnDef array\nPayment/Fulfillment badges"]
    fmt["formatters.ts\norder count labels\npreventPaginationNavigation"]

    page --> kpi
    page --> traffic
    page --> sources
    page --> top
    page --> inv
    page --> reviews
    page --> orders
    orders --> data
    orders --> schema
    orders --> cols
    orders --> fmt
    cols --> schema
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx`, line 504-527 ([link](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/blob/96fc15c14aa593ca1724a59d32586a41d0eb66a8/src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx#L504-L527)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Anomalies line effectively invisible due to shared Y-axis scale**

   The `Line` for `anomalies` shares `yAxisId="traffic"` with the `Area` for `visitors`, which uses `domain={[0, 650]}`. Anomaly values range from 1–18, so at render time a data point of 18 occupies only ~2.8% of the axis height (~6 px in a 216 px tall chart). The series will appear as a nearly-flat line at the chart floor, making the anomaly signal — rendered in the destructive/red color to indicate importance — effectively invisible to users.

   A dedicated secondary `YAxis` with an appropriate domain (e.g. `[0, 30]`) and its own `yAxisId` should be used for the anomalies `Line`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/app/(main)/dashboard/ecommerce/_components/store-traffic.tsx
   Line: 504-527

   Comment:
   **Anomalies line effectively invisible due to shared Y-axis scale**

   The `Line` for `anomalies` shares `yAxisId="traffic"` with the `Area` for `visitors`, which uses `domain={[0, 650]}`. Anomaly values range from 1–18, so at render time a data point of 18 occupies only ~2.8% of the axis height (~6 px in a 216 px tall chart). The series will appear as a nearly-flat line at the chart floor, making the anomaly signal — rendered in the destructive/red color to indicate importance — effectively invisible to users.

   A dedicated secondary `YAxis` with an appropriate domain (e.g. `[0, 30]`) and its own `yAxisId` should be used for the anomalies `Line`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/app/(main)/dashboard/ecommerce/_components/recent-orders.tsx:107-109
The `MoreHorizontal` icon button in the card header action area has no `aria-label`, unlike the two adjacent buttons (`"Open orders"` and `"Download orders"`). Screen readers will announce it as an unlabeled button, making its purpose inaccessible.

```suggestion
          <Button aria-label="More options" size="icon-sm" variant="outline">
            <MoreHorizontal />
          </Button>
```


`````

</details>

<sub>Reviews (9): Last reviewed commit: ["Add ecommerce dashboard insights"](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/8f5c37fa992008a00653c7e5bcde25b47cff84fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30887532)</sub>

<!-- /greptile_comment -->