### PR TITLE
First Connection

### DIFF
--- a/src/app/(main)/dashboard/_components/sidebar/app-sidebar.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-import { CircleHelp, ClipboardList, Command, Database, File, Search, Settings } from "lucide-react";
+import { CircleHelp, ClipboardList, Database, File, Mic, Search, Settings } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 
 import {
@@ -79,8 +79,8 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           <SidebarMenuItem>
             <SidebarMenuButton asChild>
               <Link prefetch={false} href="/dashboard/default">
-                <Command />
-                <span className="font-semibold text-base">{APP_CONFIG.name}</span>
+                <Mic className="text-primary" />
+                <span className="font-bold text-base">{APP_CONFIG.name}</span>
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/src/app/(main)/dashboard/audio-posts/_components/posts-table/columns.tsx
+++ b/src/app/(main)/dashboard/audio-posts/_components/posts-table/columns.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { Headphones, Heart, MessageCircle, MoreHorizontal, Play, Trash2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import type { PostRow } from "./schema";
+
+export const postColumns: ColumnDef<PostRow>[] = [
+  {
+    accessorKey: "title",
+    header: "Title",
+    cell: ({ row }) => (
+      <div className="flex flex-col max-w-[200px]">
+        <span className="font-medium text-sm truncate">{row.original.title}</span>
+        <span className="text-xs text-muted-foreground">{row.original.author}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "duration",
+    header: "Duration",
+    cell: ({ row }) => <div className="text-sm">{row.original.duration}</div>,
+  },
+  {
+    accessorKey: "listens",
+    header: "Stats",
+    cell: ({ row }) => (
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        <div className="flex items-center gap-1">
+          <Headphones className="h-3 w-3" /> {row.original.listens}
+        </div>
+        <div className="flex items-center gap-1">
+          <Heart className="h-3 w-3" /> {row.original.likes}
+        </div>
+        <div className="flex items-center gap-1">
+          <MessageCircle className="h-3 w-3" /> {row.original.replies}
+        </div>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const status = row.original.status;
+      return (
+        <Badge
+          variant={status === "Published" ? "default" : status === "Flagged" ? "destructive" : "secondary"}
+          className="rounded-full px-2.5"
+        >
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "timestamp",
+    header: "Date",
+    cell: ({ row }) => <div className="text-sm">{new Date(row.original.timestamp).toLocaleDateString()}</div>,
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Open menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem>
+              <Play className="mr-2 h-4 w-4" /> Listen
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="text-destructive">
+              <Trash2 className="mr-2 h-4 w-4" /> Remove Post
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
+  },
+];

--- a/src/app/(main)/dashboard/audio-posts/_components/posts-table/data.json
+++ b/src/app/(main)/dashboard/audio-posts/_components/posts-table/data.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "POST-001",
+    "title": "Life in Eastlands, Nairobi",
+    "author": "Sarah Mwangi",
+    "duration": "0:28",
+    "replies": 24,
+    "likes": 142,
+    "listens": 1205,
+    "timestamp": "2024-05-06T10:00:00Z",
+    "status": "Published"
+  },
+  {
+    "id": "POST-002",
+    "title": "My morning routine as a developer",
+    "author": "James Odhiambo",
+    "duration": "0:45",
+    "replies": 56,
+    "likes": 287,
+    "listens": 3240,
+    "timestamp": "2024-05-06T07:00:00Z",
+    "status": "Published"
+  },
+  {
+    "id": "POST-003",
+    "title": "Quick thoughts on AI and creativity",
+    "author": "Amina Hassan",
+    "duration": "0:52",
+    "replies": 89,
+    "likes": 412,
+    "listens": 5100,
+    "timestamp": "2024-05-06T04:00:00Z",
+    "status": "Flagged"
+  },
+  {
+    "id": "POST-004",
+    "title": "The best matatu experience ever",
+    "author": "Kevin Waweru",
+    "duration": "1:15",
+    "replies": 134,
+    "likes": 678,
+    "listens": 8900,
+    "timestamp": "2024-05-05T15:00:00Z",
+    "status": "Published"
+  }
+]

--- a/src/app/(main)/dashboard/audio-posts/_components/posts-table/schema.ts
+++ b/src/app/(main)/dashboard/audio-posts/_components/posts-table/schema.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const postSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  author: z.string(),
+  duration: z.string(),
+  replies: z.number(),
+  likes: z.number(),
+  listens: z.number(),
+  timestamp: z.string(),
+  status: z.enum(["Published", "Flagged", "Archived"]),
+});
+
+export type PostRow = z.infer<typeof postSchema>;

--- a/src/app/(main)/dashboard/audio-posts/_components/posts-table/table.tsx
+++ b/src/app/(main)/dashboard/audio-posts/_components/posts-table/table.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  type ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type PaginationState,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+import { postColumns } from "./columns";
+import type { PostRow } from "./schema";
+
+export function PostsTable({ data }: { data: PostRow[] }) {
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  const table = useReactTable({
+    data,
+    columns: postColumns,
+    state: {
+      rowSelection,
+      columnFilters,
+      sorting,
+      pagination,
+    },
+    onRowSelectionChange: setRowSelection,
+    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="relative w-full max-w-sm">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search posts..."
+            className="pl-8"
+            value={(table.getColumn("title")?.getFilterValue() as string) ?? ""}
+            onChange={(event) => table.getColumn("title")?.setFilterValue(event.target.value)}
+          />
+        </div>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={postColumns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/audio-posts/page.tsx
+++ b/src/app/(main)/dashboard/audio-posts/page.tsx
@@ -1,0 +1,17 @@
+import postsData from "./_components/posts-table/data.json";
+import type { PostRow } from "./_components/posts-table/schema";
+import { PostsTable } from "./_components/posts-table/table";
+
+export default function AudioPostsPage() {
+  const posts = postsData as PostRow[];
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Audio Posts</h1>
+        <p className="text-muted-foreground">Monitor and moderate audio content posted by users.</p>
+      </div>
+      <PostsTable data={posts} />
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/default/_components/metric-cards.tsx
+++ b/src/app/(main)/dashboard/default/_components/metric-cards.tsx
@@ -1,4 +1,4 @@
-import { DollarSign, TrendingDown, TrendingUp, UserPlus, Users, Waves } from "lucide-react";
+import { AudioLines, Headphones, Mic, TrendingUp, Users } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -10,62 +10,20 @@ export function MetricCards() {
         <CardHeader>
           <CardTitle>
             <div className="flex size-7 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
-              <DollarSign className="size-4" />
-            </div>
-          </CardTitle>
-          <CardDescription>Total Revenue</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">$1,250.00</div>
-            <Badge>
-              <TrendingUp className="size-3" />
-              +12.5%
-            </Badge>
-          </div>
-          <p className="text-muted-foreground text-sm">Visitors for the last 6 months</p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            <div className="flex size-7 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
-              <UserPlus className="size-4" />
-            </div>
-          </CardTitle>
-          <CardDescription>New Customers</CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">1,234</div>
-            <Badge variant="destructive">
-              <TrendingDown className="size-3" />
-              -20%
-            </Badge>
-          </div>
-          <p className="text-muted-foreground text-sm">Acquisition needs attention</p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            <div className="flex size-7 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
               <Users className="size-4" />
             </div>
           </CardTitle>
-          <CardDescription>Active Accounts</CardDescription>
+          <CardDescription>Total Users</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-1">
           <div className="flex flex-wrap items-center gap-2">
-            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">45,678</div>
+            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">12,540</div>
             <Badge>
               <TrendingUp className="size-3" />
-              +12.5%
+              +8.2%
             </Badge>
           </div>
-          <p className="text-muted-foreground text-sm">Engagement exceeds targets</p>
+          <p className="text-muted-foreground text-sm">Growth in the last 30 days</p>
         </CardContent>
       </Card>
 
@@ -73,20 +31,62 @@ export function MetricCards() {
         <CardHeader>
           <CardTitle>
             <div className="flex size-7 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
-              <Waves className="size-4" />
+              <AudioLines className="size-4" />
             </div>
           </CardTitle>
-          <CardDescription>Growth Rate</CardDescription>
+          <CardDescription>Audio Posts</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-1">
           <div className="flex flex-wrap items-center gap-2">
-            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">4.5%</div>
+            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">4,821</div>
             <Badge>
               <TrendingUp className="size-3" />
-              +4.5%
+              +15.3%
             </Badge>
           </div>
-          <p className="text-muted-foreground text-sm">Meets growth projections</p>
+          <p className="text-muted-foreground text-sm">New posts this week</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <div className="flex size-7 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
+              <Mic className="size-4" />
+            </div>
+          </CardTitle>
+          <CardDescription>Live Rooms</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">84</div>
+            <Badge>
+              <TrendingUp className="size-3" />
+              +12.5%
+            </Badge>
+          </div>
+          <p className="text-muted-foreground text-sm">Active conversations now</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <div className="flex size-7 items-center justify-center rounded-lg border bg-muted text-muted-foreground">
+              <Headphones className="size-4" />
+            </div>
+          </CardTitle>
+          <CardDescription>Total Listens</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="font-medium text-3xl tabular-nums leading-none tracking-tight">85.2K</div>
+            <Badge>
+              <TrendingUp className="size-3" />
+              +24.1%
+            </Badge>
+          </div>
+          <p className="text-muted-foreground text-sm">Cumulative audio plays</p>
         </CardContent>
       </Card>
     </div>

--- a/src/app/(main)/dashboard/users/_components/users-table/columns.tsx
+++ b/src/app/(main)/dashboard/users/_components/users-table/columns.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { MoreHorizontal, Pencil, ShieldAlert, UserMinus, UserPlus } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import type { UserRow } from "./schema";
+
+export const userColumns: ColumnDef<UserRow>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected() || (table.getIsSomePageRowsSelected() && "indeterminate")}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all users"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label={`Select ${row.original.name}`}
+      />
+    ),
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "User",
+    cell: ({ row }) => (
+      <div className="flex flex-col">
+        <span className="font-medium text-sm">{row.original.name}</span>
+        <span className="text-xs text-muted-foreground">{row.original.handle}</span>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+    cell: ({ row }) => <div className="text-sm">{row.original.email}</div>,
+  },
+  {
+    accessorKey: "role",
+    header: "Role",
+    cell: ({ row }) => (
+      <Badge variant="outline" className="rounded-full px-2.5">
+        {row.original.role}
+      </Badge>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const status = row.original.status;
+      return (
+        <Badge
+          variant={status === "Active" ? "default" : status === "Suspended" ? "destructive" : "secondary"}
+          className="rounded-full px-2.5"
+        >
+          {status}
+        </Badge>
+      );
+    },
+  },
+  {
+    accessorKey: "joined",
+    header: "Joined",
+    cell: ({ row }) => <div className="text-sm">{row.original.joined}</div>,
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      return (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0">
+              <span className="sr-only">Open menu</span>
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuItem onClick={() => navigator.clipboard.writeText(row.original.id)}>
+              Copy User ID
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>
+              <Pencil className="mr-2 h-4 w-4" /> Edit User
+            </DropdownMenuItem>
+            <DropdownMenuItem className="text-destructive">
+              <ShieldAlert className="mr-2 h-4 w-4" /> Suspend User
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
+    },
+  },
+];

--- a/src/app/(main)/dashboard/users/_components/users-table/data.json
+++ b/src/app/(main)/dashboard/users/_components/users-table/data.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "USR-001",
+    "name": "Sarah Mwangi",
+    "handle": "@sarah_m",
+    "email": "sarah.mwangi@example.com",
+    "status": "Active",
+    "role": "User",
+    "joined": "2024-01-15"
+  },
+  {
+    "id": "USR-002",
+    "name": "James Odhiambo",
+    "handle": "@james_dev",
+    "email": "james.o@example.com",
+    "status": "Active",
+    "role": "User",
+    "joined": "2024-02-20"
+  },
+  {
+    "id": "USR-003",
+    "name": "Amina Hassan",
+    "handle": "@amina_h",
+    "email": "amina.h@example.com",
+    "status": "Suspended",
+    "role": "User",
+    "joined": "2024-03-10"
+  },
+  {
+    "id": "USR-004",
+    "name": "Kevin Waweru",
+    "handle": "@kevin_w",
+    "email": "kevin.w@example.com",
+    "status": "Active",
+    "role": "Moderator",
+    "joined": "2024-01-05"
+  },
+  {
+    "id": "USR-005",
+    "name": "Diana Kamau",
+    "handle": "@diana_k",
+    "email": "diana.k@example.com",
+    "status": "Active",
+    "role": "Admin",
+    "joined": "2023-12-01"
+  }
+]

--- a/src/app/(main)/dashboard/users/_components/users-table/schema.ts
+++ b/src/app/(main)/dashboard/users/_components/users-table/schema.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  handle: z.string(),
+  email: z.string().email(),
+  status: z.enum(["Active", "Suspended", "Pending"]),
+  role: z.enum(["User", "Moderator", "Admin"]),
+  joined: z.string(),
+});
+
+export type UserRow = z.infer<typeof userSchema>;

--- a/src/app/(main)/dashboard/users/_components/users-table/table.tsx
+++ b/src/app/(main)/dashboard/users/_components/users-table/table.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import * as React from "react";
+
+import {
+  type ColumnFiltersState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  type PaginationState,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Search } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+import { userColumns } from "./columns";
+import type { UserRow } from "./schema";
+
+export function UsersTable({ data }: { data: UserRow[] }) {
+  const [rowSelection, setRowSelection] = React.useState({});
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
+  const [sorting, setSorting] = React.useState<SortingState>([]);
+  const [pagination, setPagination] = React.useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  const table = useReactTable({
+    data,
+    columns: userColumns,
+    state: {
+      rowSelection,
+      columnFilters,
+      sorting,
+      pagination,
+    },
+    onRowSelectionChange: setRowSelection,
+    onColumnFiltersChange: setColumnFilters,
+    onSortingChange: setSorting,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="relative w-full max-w-sm">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search users..."
+            className="pl-8"
+            value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
+            onChange={(event) => table.getColumn("name")?.setFilterValue(event.target.value)}
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm">
+            Export
+          </Button>
+          <Button size="sm">Add User</Button>
+        </div>
+      </div>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={userColumns.length} className="h-24 text-center">
+                  No results.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end space-x-2 py-4">
+        <div className="flex-1 text-sm text-muted-foreground">
+          {table.getFilteredSelectedRowModel().rows.length} of {table.getFilteredRowModel().rows.length} row(s)
+          selected.
+        </div>
+        <div className="space-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            Previous
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => table.nextPage()} disabled={!table.getCanNextPage()}>
+            Next
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/users/page.tsx
+++ b/src/app/(main)/dashboard/users/page.tsx
@@ -1,0 +1,17 @@
+import usersData from "./_components/users-table/data.json";
+import type { UserRow } from "./_components/users-table/schema";
+import { UsersTable } from "./_components/users-table/table";
+
+export default function UsersPage() {
+  const users = usersData as UserRow[];
+
+  return (
+    <div className="flex flex-col gap-4 md:gap-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">User Management</h1>
+        <p className="text-muted-foreground">Manage your application users, roles, and account status.</p>
+      </div>
+      <UsersTable data={users} />
+    </div>
+  );
+}

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -3,12 +3,12 @@ import packageJson from "../../package.json";
 const currentYear = new Date().getFullYear();
 
 export const APP_CONFIG = {
-  name: "Studio Admin",
+  name: "TwittAudio Admin",
   version: packageJson.version,
-  copyright: `© ${currentYear}, Studio Admin.`,
+  copyright: `© ${currentYear}, TwittAudio.`,
   meta: {
-    title: "Studio Admin - Modern Next.js Dashboard Starter Template",
+    title: "TwittAudio Admin - Control Panel",
     description:
-      "Studio Admin is a modern, open-source dashboard starter template built with Next.js 16, Tailwind CSS v4, and shadcn/ui. Perfect for SaaS apps, admin panels, and internal tools—fully customizable and production-ready.",
+      "TwittAudio Admin is the management dashboard for the TwittAudio social platform. Manage users, audio posts, and live rooms.",
   },
 };

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -1,21 +1,13 @@
 import {
-  Banknote,
-  Calendar,
+  AudioLines,
   ChartBar,
   Fingerprint,
-  Forklift,
   Gauge,
-  GraduationCap,
-  Kanban,
   LayoutDashboard,
-  ListTodo,
-  Lock,
-  type LucideIcon,
-  Mail,
-  MessageSquare,
-  ReceiptText,
-  ShoppingBag,
-  SquareArrowUpRight,
+  Mic,
+  Radio,
+  Settings,
+  ShieldCheck,
   Users,
 } from "lucide-react";
 
@@ -47,98 +39,54 @@ export interface NavGroup {
 export const sidebarItems: NavGroup[] = [
   {
     id: 1,
-    label: "Dashboards",
+    label: "Overview",
     items: [
       {
-        title: "Default",
+        title: "Dashboard",
         url: "/dashboard/default",
         icon: LayoutDashboard,
-      },
-      {
-        title: "CRM",
-        url: "/dashboard/crm",
-        icon: ChartBar,
-      },
-      {
-        title: "Finance",
-        url: "/dashboard/finance",
-        icon: Banknote,
       },
       {
         title: "Analytics",
         url: "/dashboard/analytics",
         icon: Gauge,
       },
-      {
-        title: "Productivity",
-        url: "/dashboard/productivity",
-        icon: ListTodo,
-      },
-      {
-        title: "E-commerce",
-        url: "/dashboard/coming-soon",
-        icon: ShoppingBag,
-        comingSoon: true,
-      },
-      {
-        title: "Academy",
-        url: "/dashboard/coming-soon",
-        icon: GraduationCap,
-        comingSoon: true,
-      },
-      {
-        title: "Logistics",
-        url: "/dashboard/coming-soon",
-        icon: Forklift,
-        comingSoon: true,
-      },
     ],
   },
   {
     id: 2,
-    label: "Pages",
+    label: "Management",
     items: [
       {
-        title: "Email",
-        url: "/dashboard/coming-soon",
-        icon: Mail,
-        comingSoon: true,
-      },
-      {
-        title: "Chat",
-        url: "/dashboard/coming-soon",
-        icon: MessageSquare,
-        comingSoon: true,
-      },
-      {
-        title: "Calendar",
-        url: "/dashboard/coming-soon",
-        icon: Calendar,
-        comingSoon: true,
-      },
-      {
-        title: "Kanban",
-        url: "/dashboard/coming-soon",
-        icon: Kanban,
-        comingSoon: true,
-      },
-      {
-        title: "Invoice",
-        url: "/dashboard/coming-soon",
-        icon: ReceiptText,
-        comingSoon: true,
-      },
-      {
         title: "Users",
-        url: "/dashboard/coming-soon",
+        url: "/dashboard/users",
         icon: Users,
-        comingSoon: true,
       },
       {
-        title: "Roles",
+        title: "Audio Posts",
+        url: "/dashboard/audio-posts",
+        icon: AudioLines,
+      },
+      {
+        title: "Live Rooms",
         url: "/dashboard/coming-soon",
-        icon: Lock,
-        comingSoon: true,
+        icon: Radio,
+      },
+    ],
+  },
+  {
+    id: 3,
+    label: "Platform",
+    items: [
+      {
+        title: "Moderation",
+        url: "/dashboard/coming-soon",
+        icon: ShieldCheck,
+      },
+      {
+        title: "Settings",
+        url: "/dashboard/coming-soon",
+        icon: Settings,
       },
       {
         title: "Authentication",
@@ -150,34 +98,6 @@ export const sidebarItems: NavGroup[] = [
           { title: "Register v1", url: "/auth/v1/register", newTab: true },
           { title: "Register v2", url: "/auth/v2/register", newTab: true },
         ],
-      },
-    ],
-  },
-  {
-    id: 3,
-    label: "Legacy",
-    items: [
-      {
-        title: "Dashboards",
-        url: "/dashboard/default-v1",
-        subItems: [
-          { title: "Default V1", url: "/dashboard/default-v1" },
-          { title: "CRM V1", url: "/dashboard/crm-v1" },
-          { title: "Finance V1", url: "/dashboard/finance-v1" },
-          { title: "Analytics V1", url: "/dashboard/analytics-v1" },
-        ],
-      },
-    ],
-  },
-  {
-    id: 4,
-    label: "Misc",
-    items: [
-      {
-        title: "Others",
-        url: "/dashboard/coming-soon",
-        icon: SquareArrowUpRight,
-        comingSoon: true,
       },
     ],
   },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rebrands the dashboard from "Studio Admin" to "TwittAudio Admin" and adds two new data-table pages (Users and Audio Posts) with Zod schemas, static JSON fixtures, and TanStack Table components.

- **Sidebar restructured**: navigation groups renamed to Overview / Management / Platform; three new placeholder items (Live Rooms, Moderation, Settings) point to `/dashboard/coming-soon` but are missing the `comingSoon: true` flag present on all other placeholder routes, so they will appear as live links.
- **Two new table pages added**: `users` and `audio-posts` each follow the same schema → JSON → table component pattern, though both pages cast the JSON directly with `as T[]` instead of parsing through the Zod schema.
- **Unused imports** left behind in `sidebar-items.ts` (`ChartBar`, `Mic`) and `users/columns.tsx` (`UserMinus`, `UserPlus`).

<h3>Confidence Score: 3/5</h3>

The core table pages render correctly, but three new sidebar items will behave as fully live navigation links rather than showing the expected coming-soon indicator.

Three placeholder sidebar items are missing the comingSoon: true flag that every other placeholder in the sidebar carries, causing them to render as functional links — a present behavioral difference from the intended UI contract.

src/navigation/sidebar/sidebar-items.ts — missing comingSoon flags and unused imports; src/app/(main)/dashboard/audio-posts/page.tsx and src/app/(main)/dashboard/users/page.tsx — JSON data cast rather than schema-parsed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/navigation/sidebar/sidebar-items.ts | Sidebar restructured for TwittAudio; two unused imports (ChartBar, Mic) and three coming-soon items missing the comingSoon flag. |
| src/app/(main)/dashboard/users/_components/users-table/columns.tsx | New users table column definitions; UserMinus and UserPlus icons imported but never used. |
| src/app/(main)/dashboard/audio-posts/page.tsx | New Audio Posts page using a type assertion instead of Zod schema parsing for static data. |
| src/app/(main)/dashboard/users/page.tsx | New User Management page; casts JSON data rather than parsing through the Zod schema. |
| src/app/(main)/dashboard/audio-posts/_components/posts-table/columns.tsx | New audio posts table column definitions; well-structured with correct badge variant logic. |
| src/app/(main)/dashboard/audio-posts/_components/posts-table/table.tsx | New posts table component with search, pagination, sorting, and filtering. |
| src/app/(main)/dashboard/users/_components/users-table/table.tsx | New users table component with row selection, search, pagination, and export/add-user buttons. |
| src/config/app-config.ts | App name and metadata updated from Studio Admin to TwittAudio Admin — straightforward rebrand. |
| src/app/(main)/dashboard/default/_components/metric-cards.tsx | Metric cards updated to reflect audio platform KPIs (Users, Audio Posts, Live Rooms, Total Listens). |
| src/app/(main)/dashboard/_components/sidebar/app-sidebar.tsx | Sidebar branding updated: Command icon replaced with Mic, font-semibold upgraded to font-bold. |
| src/app/(main)/dashboard/audio-posts/_components/posts-table/schema.ts | Zod schema for PostRow correctly defines status enum and all numeric fields. |
| src/app/(main)/dashboard/users/_components/users-table/schema.ts | Zod schema for UserRow with email validation and status/role enums — well defined. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sidebar Navigation] --> B[Overview]
    A --> C[Management]
    A --> D[Platform]
    B --> B1[Dashboard]
    B --> B2[Analytics]
    C --> C1[Users]
    C --> C2[Audio Posts]
    C --> C3[Live Rooms - missing comingSoon flag]
    D --> D1[Moderation - missing comingSoon flag]
    D --> D2[Settings - missing comingSoon flag]
    D --> D3[Authentication]
    C1 --> E[UsersPage]
    E --> E1[data.json cast as UserRow]
    E --> E2[UsersTable]
    C2 --> F[AudioPostsPage]
    F --> F1[data.json cast as PostRow]
    F --> F2[PostsTable]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
src/navigation/sidebar/sidebar-items.ts:60-75
**Missing `comingSoon` flag on placeholder routes**

"Live Rooms", "Moderation", and "Settings" all resolve to `/dashboard/coming-soon`, but unlike every other placeholder item in the original sidebar they lack the `comingSoon: true` property. Without this flag the sidebar will render them as ordinary navigation links with no "coming soon" badge, giving users the impression the features are live.

```suggestion
      {
        title: "Live Rooms",
        url: "/dashboard/coming-soon",
        icon: Radio,
        comingSoon: true,
      },
    ],
  },
  {
    id: 3,
    label: "Platform",
    items: [
      {
        title: "Moderation",
        url: "/dashboard/coming-soon",
        icon: ShieldCheck,
        comingSoon: true,
      },
      {
        title: "Settings",
        url: "/dashboard/coming-soon",
        icon: Settings,
        comingSoon: true,
      },
```

### Issue 2 of 4
src/navigation/sidebar/sidebar-items.ts:1-12
**Unused icon imports**

`ChartBar` and `Mic` are imported from lucide-react but neither is assigned to any sidebar item in the updated configuration. This will cause lint/compile warnings and unnecessarily increases the bundle size.

```suggestion
import {
  AudioLines,
  Fingerprint,
  Gauge,
  LayoutDashboard,
  Radio,
  Settings,
  ShieldCheck,
  Users,
} from "lucide-react";
```

### Issue 3 of 4
src/app/(main)/dashboard/users/_components/users-table/columns.tsx:4
**Unused icon imports**

`UserMinus` and `UserPlus` are imported but never referenced in any cell renderer or action menu item. Only `Pencil` and `ShieldAlert` are actually used in the actions dropdown.

```suggestion
import { MoreHorizontal, Pencil, ShieldAlert } from "lucide-react";
```

### Issue 4 of 4
src/app/(main)/dashboard/audio-posts/page.tsx:4
**Zod schema defined but never used for validation**

`postsData` is cast with `as PostRow[]` (and similarly `usersData as UserRow[]` in `users/page.tsx`) rather than parsed through the Zod schema. If the shape of the static JSON diverges from the schema, TypeScript will not catch it and the table will silently receive malformed data. Consider `postSchema.array().parse(postsData)` so schema validation is enforced at module load.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["First Cpnnection"](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/e636e6b37972b24678633c1a8deed04e91f0cc0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31236760)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->