### PR TITLE
feat: academy dashboard

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -63,7 +63,7 @@
         "noMisusedPromises": "error"
       },
       "performance": {
-        "noImgElement": "warn"
+        "noImgElement": "off"
       },
       "style": {
         "noCommonJs": "error",

--- a/biome.json
+++ b/biome.json
@@ -63,7 +63,7 @@
         "noMisusedPromises": "error"
       },
       "performance": {
-        "noImgElement": "off"
+        "noImgElement": "warn"
       },
       "style": {
         "noCommonJs": "error",

--- a/src/app/(main)/dashboard/academy/_components/assignment-status.tsx
+++ b/src/app/(main)/dashboard/academy/_components/assignment-status.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+const chartData = [
+  { className: "G11A", submitted: 14, pending: 18, overdue: 2 },
+  { className: "G11B", submitted: 22, pending: 7, overdue: 3 },
+  { className: "G11C", submitted: 10, pending: 19, overdue: 5 },
+  { className: "G11D", submitted: 17, pending: 15, overdue: 6 },
+  { className: "G11E", submitted: 24, pending: 4, overdue: 2 },
+];
+
+function SubmittedLegendIcon() {
+  return <span className="block size-2 rounded-[2px] bg-chart-3" />;
+}
+
+function PendingLegendIcon() {
+  return <span className="block size-2 rounded-[2px] bg-chart-2" />;
+}
+
+function OverdueLegendIcon() {
+  return <span className="block size-2 rounded-[2px] bg-destructive" />;
+}
+
+const chartConfig = {
+  submitted: {
+    label: "Submitted",
+    color: "var(--chart-3)",
+    icon: SubmittedLegendIcon,
+  },
+  pending: {
+    label: "Pending",
+    color: "var(--chart-2)",
+    icon: PendingLegendIcon,
+  },
+  overdue: {
+    label: "Overdue",
+    color: "var(--destructive)",
+    icon: OverdueLegendIcon,
+  },
+} satisfies ChartConfig;
+
+function AssignmentDotPattern({ color, id }: { color: string; id: string }) {
+  return (
+    <pattern id={id} width="6" height="6" patternUnits="userSpaceOnUse">
+      <rect width="6" height="6" fill={color} fillOpacity="0.7" />
+      <circle cx="1.5" cy="1.5" r="0.8" fill={color} fillOpacity="0.25" />
+      <circle cx="4.5" cy="4.5" r="0.8" fill={color} fillOpacity="0.25" />
+    </pattern>
+  );
+}
+
+export function AssignmentStatus() {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="text-sm">Assignment Status</CardTitle>
+        <CardAction className="flex items-center gap-1 text-muted-foreground text-xs">
+          View Report <ArrowRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-70 w-full">
+          <BarChart accessibilityLayer data={chartData} margin={{ left: 0, right: 0, top: 0, bottom: 0 }}>
+            <defs>
+              <AssignmentDotPattern color="var(--color-submitted)" id="assignment-submitted-pattern" />
+              <AssignmentDotPattern color="var(--color-pending)" id="assignment-pending-pattern" />
+              <AssignmentDotPattern color="var(--color-overdue)" id="assignment-overdue-pattern" />
+            </defs>
+            <CartesianGrid vertical={false} />
+            <XAxis axisLine={false} dataKey="className" tickLine={false} tickMargin={10} />
+            <ChartTooltip cursor={false} content={<ChartTooltipContent hideIndicator />} />
+            <ChartLegend content={<ChartLegendContent className="justify-start" />} verticalAlign="top" />
+            <Bar
+              dataKey="submitted"
+              fill="url(#assignment-submitted-pattern)"
+              radius={4}
+              stroke="var(--color-submitted)"
+              strokeOpacity={0.45}
+              strokeWidth={0.5}
+            />
+            <Bar
+              dataKey="pending"
+              fill="url(#assignment-pending-pattern)"
+              radius={4}
+              stroke="var(--color-pending)"
+              strokeOpacity={0.5}
+              strokeWidth={0.5}
+            />
+            <Bar
+              dataKey="overdue"
+              fill="url(#assignment-overdue-pattern)"
+              radius={4}
+              stroke="var(--color-overdue)"
+              strokeOpacity={0.5}
+              strokeWidth={0.5}
+            />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/academy/_components/class-schedule.tsx
+++ b/src/app/(main)/dashboard/academy/_components/class-schedule.tsx
@@ -1,9 +1,12 @@
+import { format } from "date-fns";
 import { ArrowRight } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export function ClassSchedule() {
+  const today = format(new Date(), "EEEE, d MMMM");
+
   return (
     <Card>
       <CardHeader>
@@ -19,7 +22,7 @@ export function ClassSchedule() {
               <div className="w-1 shrink-0 rounded-md bg-green-600 dark:bg-green-400" />
               <div className="text-nowrap text-xs">
                 <div className="font-medium text-foreground">08:00 - 08:45</div>
-                <div className="text-muted-foreground">Tuesday, 12 May</div>
+                <div className="text-muted-foreground">{today}</div>
               </div>
             </div>
 
@@ -41,7 +44,7 @@ export function ClassSchedule() {
               <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
               <div className="text-nowrap text-xs">
                 <div className="font-medium text-foreground">09:00 - 09:45</div>
-                <div className="text-muted-foreground">Tuesday, 12 May</div>
+                <div className="text-muted-foreground">{today}</div>
               </div>
             </div>
 
@@ -63,7 +66,7 @@ export function ClassSchedule() {
               <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
               <div className="text-nowrap text-xs">
                 <div className="font-medium text-foreground">10:00 - 10:45</div>
-                <div className="text-muted-foreground">Tuesday, 12 May</div>
+                <div className="text-muted-foreground">{today}</div>
               </div>
             </div>
 
@@ -85,7 +88,7 @@ export function ClassSchedule() {
               <div className="w-1 shrink-0 rounded-md bg-destructive" />
               <div className="text-nowrap text-xs">
                 <div className="font-medium text-foreground">11:00 - 11:45</div>
-                <div className="text-muted-foreground">Tuesday, 12 May</div>
+                <div className="text-muted-foreground">{today}</div>
               </div>
             </div>
 
@@ -107,35 +110,13 @@ export function ClassSchedule() {
               <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
               <div className="text-nowrap text-xs">
                 <div className="font-medium text-foreground">12:00 - 12:45</div>
-                <div className="text-muted-foreground">Tuesday, 12 May</div>
+                <div className="text-muted-foreground">{today}</div>
               </div>
             </div>
 
             <div className="flex min-w-0 flex-col gap-1">
               <div className="truncate font-medium text-foreground text-sm leading-none">Computer Science</div>
               <div className="truncate text-muted-foreground text-xs leading-none">Grade 11B • Computing Lab</div>
-            </div>
-
-            <Badge
-              variant="secondary"
-              className="shrink-0 rounded-md border-yellow-600/50 bg-yellow-50 px-2.5 py-1 font-medium text-[10px] text-yellow-700 dark:border-yellow-800/50 dark:bg-yellow-500/10 dark:text-yellow-300"
-            >
-              Upcoming
-            </Badge>
-          </div>
-
-          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
-            <div className="flex gap-2">
-              <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
-              <div className="text-nowrap text-xs">
-                <div className="font-medium text-foreground">13:00 - 13:45</div>
-                <div className="text-muted-foreground">Tuesday, 12 May</div>
-              </div>
-            </div>
-
-            <div className="flex min-w-0 flex-col gap-1">
-              <div className="truncate font-medium text-foreground text-sm leading-none">Chemistry</div>
-              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11C • Chemistry Lab</div>
             </div>
 
             <Badge

--- a/src/app/(main)/dashboard/academy/_components/class-schedule.tsx
+++ b/src/app/(main)/dashboard/academy/_components/class-schedule.tsx
@@ -1,0 +1,152 @@
+import { ArrowRight } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function ClassSchedule() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Class Schedule</CardTitle>
+        <CardAction className="flex items-center gap-1 text-muted-foreground text-xs">
+          View Full Schedule <ArrowRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-0">
+        <div className="flex flex-col divide-y divide-border">
+          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
+            <div className="flex gap-2">
+              <div className="w-1 shrink-0 rounded-md bg-green-600 dark:bg-green-400" />
+              <div className="text-nowrap text-xs">
+                <div className="font-medium text-foreground">08:00 - 08:45</div>
+                <div className="text-muted-foreground">Tuesday, 12 May</div>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="truncate font-medium text-foreground text-sm leading-none">Pure Mathematics</div>
+              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11A • Room 2.14</div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-md border-green-600/50 bg-green-50 px-2.5 py-1 font-medium text-[10px] text-green-600 dark:border-green-800/50 dark:bg-green-500/10 dark:text-green-400"
+            >
+              In Progress
+            </Badge>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
+            <div className="flex gap-2">
+              <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
+              <div className="text-nowrap text-xs">
+                <div className="font-medium text-foreground">09:00 - 09:45</div>
+                <div className="text-muted-foreground">Tuesday, 12 May</div>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="truncate font-medium text-foreground text-sm leading-none">English Literature</div>
+              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11B • Seminar Room 3</div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-md border-yellow-600/50 bg-yellow-50 px-2.5 py-1 font-medium text-[10px] text-yellow-700 dark:border-yellow-800/50 dark:bg-yellow-500/10 dark:text-yellow-300"
+            >
+              Upcoming
+            </Badge>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
+            <div className="flex gap-2">
+              <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
+              <div className="text-nowrap text-xs">
+                <div className="font-medium text-foreground">10:00 - 10:45</div>
+                <div className="text-muted-foreground">Tuesday, 12 May</div>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="truncate font-medium text-foreground text-sm leading-none">Physics</div>
+              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11C • Physics Lab</div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-md border-yellow-600/50 bg-yellow-50 px-2.5 py-1 font-medium text-[10px] text-yellow-700 dark:border-yellow-800/50 dark:bg-yellow-500/10 dark:text-yellow-300"
+            >
+              Upcoming
+            </Badge>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
+            <div className="flex gap-2">
+              <div className="w-1 shrink-0 rounded-md bg-destructive" />
+              <div className="text-nowrap text-xs">
+                <div className="font-medium text-foreground">11:00 - 11:45</div>
+                <div className="text-muted-foreground">Tuesday, 12 May</div>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="truncate font-medium text-foreground text-sm leading-none">Modern European History</div>
+              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11A • Room 1.08</div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-md border-destructive/50 bg-destructive/10 px-2.5 py-1 font-medium text-[10px] text-destructive dark:border-destructive/50 dark:bg-destructive/20"
+            >
+              Cancelled
+            </Badge>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
+            <div className="flex gap-2">
+              <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
+              <div className="text-nowrap text-xs">
+                <div className="font-medium text-foreground">12:00 - 12:45</div>
+                <div className="text-muted-foreground">Tuesday, 12 May</div>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="truncate font-medium text-foreground text-sm leading-none">Computer Science</div>
+              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11B • Computing Lab</div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-md border-yellow-600/50 bg-yellow-50 px-2.5 py-1 font-medium text-[10px] text-yellow-700 dark:border-yellow-800/50 dark:bg-yellow-500/10 dark:text-yellow-300"
+            >
+              Upcoming
+            </Badge>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 bg-card py-3 transition-colors hover:bg-muted/30 sm:grid-cols-[10rem_1fr_auto] sm:items-center">
+            <div className="flex gap-2">
+              <div className="w-1 shrink-0 rounded-md bg-yellow-500 dark:bg-yellow-400" />
+              <div className="text-nowrap text-xs">
+                <div className="font-medium text-foreground">13:00 - 13:45</div>
+                <div className="text-muted-foreground">Tuesday, 12 May</div>
+              </div>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1">
+              <div className="truncate font-medium text-foreground text-sm leading-none">Chemistry</div>
+              <div className="truncate text-muted-foreground text-xs leading-none">Grade 11C • Chemistry Lab</div>
+            </div>
+
+            <Badge
+              variant="secondary"
+              className="shrink-0 rounded-md border-yellow-600/50 bg-yellow-50 px-2.5 py-1 font-medium text-[10px] text-yellow-700 dark:border-yellow-800/50 dark:bg-yellow-500/10 dark:text-yellow-300"
+            >
+              Upcoming
+            </Badge>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
+++ b/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
@@ -67,9 +67,9 @@ export function KpiCards() {
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col">
-            <div className="text-3xl text-foreground leading-none tracking-tight">42</div>
+            <div className="text-3xl text-foreground leading-none tracking-tight">6</div>
 
-            <div className="text-right text-muted-foreground text-xs">28 completed · 14 remaining</div>
+            <div className="text-right text-muted-foreground text-xs">1 in progress · 5 remaining</div>
           </CardContent>
         </Card>
       </div>

--- a/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
+++ b/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
@@ -1,0 +1,88 @@
+import { ArrowDown, ArrowUp, Info } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function KpiCards() {
+  return (
+    <section className="space-y-5">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Total Enrollment</CardTitle>
+            <CardAction>
+              <Info className="size-3 text-muted-foreground" />
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-3xl text-foreground leading-none tracking-tight">1,245</span>
+              <Badge className="rounded-sm border-green-600/50 bg-green-500/10 px-1 font-normal text-green-700 text-xs dark:border-green-800/50 dark:bg-green-500/15 dark:text-green-300">
+                <ArrowUp />
+                2.8%
+              </Badge>
+            </div>
+            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Avg. Attendance</CardTitle>
+            <CardAction>
+              <Info className="size-3 text-muted-foreground" />
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-3xl text-foreground leading-none tracking-tight">94.2%</span>
+              <Badge className="rounded-sm border-green-600/50 bg-green-500/10 px-1 font-normal text-green-700 text-xs dark:border-green-800/50 dark:bg-green-500/15 dark:text-green-300">
+                <ArrowUp />
+                1.1%
+              </Badge>
+            </div>
+            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Faculty Members</CardTitle>
+            <CardAction>
+              <Info className="size-3 text-muted-foreground" />
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-3xl text-foreground leading-none tracking-tight">112</span>
+              <Badge className="rounded-sm border-destructive/50 bg-rose-500/10 px-1 font-normal text-destructive text-xs">
+                <ArrowDown />
+                2.4%
+              </Badge>
+            </div>
+            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Active Courses</CardTitle>
+            <CardAction>
+              <Info className="size-3 text-muted-foreground" />
+            </CardAction>
+          </CardHeader>
+          <CardContent className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <span className="text-3xl text-foreground leading-none tracking-tight">142</span>
+              <Badge className="rounded-sm border-green-600/50 bg-green-500/10 px-1 font-normal text-green-700 text-xs dark:border-green-800/50 dark:bg-green-500/15 dark:text-green-300">
+                <ArrowUp />
+                8.5%
+              </Badge>
+            </div>
+            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
+++ b/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
@@ -9,20 +9,20 @@ export function KpiCards() {
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <Card>
           <CardHeader>
-            <CardTitle className="text-sm">Total Students</CardTitle>
+            <CardTitle className="text-sm">Students Taught</CardTitle>
             <CardAction>
               <Info className="size-3 text-muted-foreground" />
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col">
             <div className="flex items-center gap-2">
-              <span className="text-3xl text-foreground leading-none tracking-tight">1,245</span>
+              <span className="text-3xl text-foreground leading-none tracking-tight">128</span>
               <Badge className="rounded-sm border-green-600/50 bg-green-500/10 px-1 font-normal text-green-700 text-xs dark:border-green-800/50 dark:bg-green-500/15 dark:text-green-300">
                 <ArrowUp />
                 2.8%
               </Badge>
             </div>
-            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+            <div className="text-right text-muted-foreground text-xs">across 5 Grade 11 sections</div>
           </CardContent>
         </Card>
 
@@ -53,9 +53,9 @@ export function KpiCards() {
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col">
-            <div className="text-3xl text-foreground leading-none tracking-tight">18</div>
+            <div className="text-3xl text-foreground leading-none tracking-tight">81</div>
 
-            <div className="text-right text-muted-foreground text-xs">12 to mark · 6 late</div>
+            <div className="text-right text-muted-foreground text-xs">63 pending · 18 overdue</div>
           </CardContent>
         </Card>
 
@@ -67,9 +67,9 @@ export function KpiCards() {
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col">
-            <div className="text-3xl text-foreground leading-none tracking-tight">6</div>
+            <div className="text-3xl text-foreground leading-none tracking-tight">5</div>
 
-            <div className="text-right text-muted-foreground text-xs">1 in progress · 5 remaining</div>
+            <div className="text-right text-muted-foreground text-xs">1 in progress · 3 upcoming · 1 cancelled</div>
           </CardContent>
         </Card>
       </div>

--- a/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
+++ b/src/app/(main)/dashboard/academy/_components/kpi-cards.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, Info } from "lucide-react";
+import { ArrowUp, Info } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,7 +9,7 @@ export function KpiCards() {
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         <Card>
           <CardHeader>
-            <CardTitle className="text-sm">Total Enrollment</CardTitle>
+            <CardTitle className="text-sm">Total Students</CardTitle>
             <CardAction>
               <Info className="size-3 text-muted-foreground" />
             </CardAction>
@@ -41,45 +41,35 @@ export function KpiCards() {
                 1.1%
               </Badge>
             </div>
-            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+            <div className="text-right text-muted-foreground text-xs">vs last month</div>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle className="text-sm">Faculty Members</CardTitle>
+            <CardTitle className="text-sm">Assignments</CardTitle>
             <CardAction>
               <Info className="size-3 text-muted-foreground" />
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col">
-            <div className="flex items-center gap-2">
-              <span className="text-3xl text-foreground leading-none tracking-tight">112</span>
-              <Badge className="rounded-sm border-destructive/50 bg-rose-500/10 px-1 font-normal text-destructive text-xs">
-                <ArrowDown />
-                2.4%
-              </Badge>
-            </div>
-            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+            <div className="text-3xl text-foreground leading-none tracking-tight">18</div>
+
+            <div className="text-right text-muted-foreground text-xs">12 to mark · 6 late</div>
           </CardContent>
         </Card>
 
         <Card>
           <CardHeader>
-            <CardTitle className="text-sm">Active Courses</CardTitle>
+            <CardTitle className="text-sm">Classes Today</CardTitle>
             <CardAction>
               <Info className="size-3 text-muted-foreground" />
             </CardAction>
           </CardHeader>
           <CardContent className="flex flex-col">
-            <div className="flex items-center gap-2">
-              <span className="text-3xl text-foreground leading-none tracking-tight">142</span>
-              <Badge className="rounded-sm border-green-600/50 bg-green-500/10 px-1 font-normal text-green-700 text-xs dark:border-green-800/50 dark:bg-green-500/15 dark:text-green-300">
-                <ArrowUp />
-                8.5%
-              </Badge>
-            </div>
-            <div className="text-right text-muted-foreground text-xs">vs last semester</div>
+            <div className="text-3xl text-foreground leading-none tracking-tight">42</div>
+
+            <div className="text-right text-muted-foreground text-xs">28 completed · 14 remaining</div>
           </CardContent>
         </Card>
       </div>

--- a/src/app/(main)/dashboard/academy/_components/performance-highlights.tsx
+++ b/src/app/(main)/dashboard/academy/_components/performance-highlights.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { ArrowRight } from "lucide-react";
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { type ChartConfig, ChartContainer } from "@/components/ui/chart";
+
+const performanceHighlights = [
+  {
+    className: "G11A",
+    start: 1.25,
+    duration: 1.45,
+    subject: "Pure Math",
+    score: 84,
+    avatars: ["AM", "LS", "NK"],
+  },
+  {
+    className: "G11B",
+    start: 0.72,
+    duration: 1.75,
+    subject: "Literature",
+    score: 78,
+    avatars: ["IR"],
+  },
+  {
+    className: "G11C",
+    start: 1.35,
+    duration: 1.9,
+    subject: "Physics",
+    score: 80,
+    avatars: ["SK", "MJ", "AT"],
+  },
+  {
+    className: "G11D",
+    start: 2.22,
+    duration: 1.66,
+    subject: "History",
+    score: 73,
+    avatars: ["RP", "EH"],
+  },
+];
+
+const chartConfig = {
+  duration: {
+    label: "Score",
+    color: "var(--chart-3)",
+  },
+} satisfies ChartConfig;
+
+type PerformanceHighlight = (typeof performanceHighlights)[number];
+
+function PerformanceHighlightBar({
+  height = 0,
+  payload,
+  width = 0,
+  x = 0,
+  y = 0,
+}: {
+  height?: number;
+  payload?: PerformanceHighlight;
+  width?: number;
+  x?: number;
+  y?: number;
+}) {
+  if (!payload) {
+    return null;
+  }
+
+  const barHeight = Math.min(32, height);
+  const barY = y + (height - barHeight) / 2;
+  const radius = barHeight / 2;
+  const fillWidth = Math.max(width * (payload.score / 100), 86);
+  const avatarSize = 22;
+  const avatarStart = x + 8;
+  const avatarY = barY + (barHeight - avatarSize) / 2 - 1.5;
+  const labelX = avatarStart + payload.avatars.length * 14 + 14;
+
+  return (
+    <g>
+      <rect
+        fill="color-mix(in oklch, var(--color-duration) 18%, transparent)"
+        height={barHeight}
+        rx={radius}
+        width={width}
+        x={x}
+        y={barY}
+      />
+      <rect fill="var(--color-duration)" height={barHeight} rx={radius} width={fillWidth} x={x} y={barY} />
+
+      {payload.avatars.map((initials, index) => {
+        const avatarX = avatarStart + index * 14;
+
+        return (
+          <foreignObject height={avatarSize + 4} key={initials} width={avatarSize + 4} x={avatarX - 2} y={avatarY}>
+            <Avatar className="size-5 bg-muted" size="sm">
+              <AvatarFallback className="text-foreground">{initials}</AvatarFallback>
+            </Avatar>
+          </foreignObject>
+        );
+      })}
+
+      <text
+        dominantBaseline="middle"
+        fill="var(--background)"
+        x={labelX}
+        y={barY + barHeight / 2 + 0.5}
+        className="font-medium text-xs"
+      >
+        {payload.subject}
+      </text>
+
+      <text
+        dominantBaseline="middle"
+        fill="var(--foreground)"
+        fontSize={11}
+        textAnchor="end"
+        x={x + width - 10}
+        y={barY + barHeight / 2 + 0.5}
+        className="font-medium tabular-nums"
+      >
+        {payload.score}%
+      </text>
+    </g>
+  );
+}
+
+export function PerformanceHighlights() {
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="text-sm">Performance Highlights</CardTitle>
+        <CardAction className="flex items-center gap-1 text-muted-foreground text-xs">
+          View Insights <ArrowRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className="h-70 w-full">
+          <BarChart
+            accessibilityLayer
+            data={performanceHighlights}
+            layout="vertical"
+            margin={{ bottom: 0, left: 0, right: 8, top: 0 }}
+          >
+            <CartesianGrid horizontal={false} strokeDasharray="4 4" />
+            <XAxis
+              axisLine={false}
+              domain={[0, 4]}
+              tickFormatter={(value) => ["Mon", "Tue", "Wed", "Thu", "Fri"][Number(value)] ?? ""}
+              tickLine={false}
+              tickMargin={10}
+              ticks={[0, 1, 2, 3, 4]}
+              type="number"
+            />
+            <YAxis axisLine={false} dataKey="className" tickLine={false} tickMargin={10} type="category" width={45} />
+            <Bar dataKey="start" fill="transparent" stackId="timeline" />
+            <Bar dataKey="duration" shape={<PerformanceHighlightBar />} stackId="timeline" />
+          </BarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/academy/_components/performance-highlights.tsx
+++ b/src/app/(main)/dashboard/academy/_components/performance-highlights.tsx
@@ -103,10 +103,9 @@ function PerformanceHighlightBar({
 
       <text
         dominantBaseline="middle"
-        fill="var(--background)"
         x={labelX}
         y={barY + barHeight / 2 + 0.5}
-        className="font-medium text-xs"
+        className="fill-primary-foreground font-medium text-xs"
       >
         {payload.subject}
       </text>

--- a/src/app/(main)/dashboard/academy/_components/upcoming-events.tsx
+++ b/src/app/(main)/dashboard/academy/_components/upcoming-events.tsx
@@ -1,0 +1,79 @@
+import { addDays, format } from "date-fns";
+import { ArrowRight } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const upcomingEvents = [
+  {
+    dayOffset: 6,
+    title: "Science Exhibition",
+    time: "08:30 AM - 12:30 PM",
+    type: "On Campus",
+  },
+  {
+    dayOffset: 9,
+    title: "Parents' Evening",
+    time: "02:00 PM - 05:00 PM",
+    type: "Meeting",
+  },
+  {
+    dayOffset: 12,
+    title: "Inter-House Sports Day",
+    time: "09:00 AM - 04:00 PM",
+    type: "Sports",
+  },
+  {
+    dayOffset: 15,
+    title: "Grade 11 Mock Exam",
+    time: "09:00 AM - 12:00 PM",
+    type: "Exam",
+  },
+  {
+    dayOffset: 18,
+    title: "Department Planning",
+    time: "03:30 PM - 04:30 PM",
+    type: "Meeting",
+  },
+];
+
+export function UpcomingEvents() {
+  const today = new Date();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Upcoming Events</CardTitle>
+        <CardAction className="flex items-center gap-1 text-muted-foreground text-xs">
+          View Calendar <ArrowRight className="size-4" />
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {upcomingEvents.map((event) => {
+          const eventDate = addDays(today, event.dayOffset);
+
+          return (
+            <div key={event.title} className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2">
+                <div className="size-11 shrink-0 overflow-hidden rounded-sm border">
+                  <div className="grid h-1/3 place-items-center border-b bg-muted font-medium text-[10px] uppercase leading-none">
+                    {format(eventDate, "MMM")}
+                  </div>
+                  <div className="grid h-2/3 place-items-center text-lg leading-none">{format(eventDate, "d")}</div>
+                </div>
+
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="truncate font-medium text-sm leading-none">{event.title}</div>
+                  <div className="text-muted-foreground text-xs leading-none">{event.time}</div>
+                </div>
+              </div>
+              <Badge variant="outline" className="shrink-0 rounded-md px-2.5 py-1 font-medium text-[10px]">
+                {event.type}
+              </Badge>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(main)/dashboard/academy/page.tsx
+++ b/src/app/(main)/dashboard/academy/page.tsx
@@ -2,6 +2,7 @@ import { BarChart3, Plus, UserPlus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
+import { ClassSchedule } from "./_components/class-schedule";
 import { KpiCards } from "./_components/kpi-cards";
 
 export default function Page() {
@@ -31,9 +32,11 @@ export default function Page() {
         </div>
       </div>
 
+      <KpiCards />
+
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
-        <div className="xl:col-span-12">
-          <KpiCards />
+        <div className="xl:col-span-5">
+          <ClassSchedule />
         </div>
       </div>
     </div>

--- a/src/app/(main)/dashboard/academy/page.tsx
+++ b/src/app/(main)/dashboard/academy/page.tsx
@@ -1,0 +1,41 @@
+import { BarChart3, Plus, UserPlus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+import { KpiCards } from "./_components/kpi-cards";
+
+export default function Page() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl tracking-tight">Academy Dashboard</h1>
+          <p className="text-muted-foreground text-sm">
+            Good morning, Admin. Here's a quick overview of today's activity.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 lg:w-fit">
+          <Button size="sm">
+            <Plus />
+            New Announcement
+          </Button>
+          <Button size="sm" variant="outline">
+            <BarChart3 />
+            View Results
+          </Button>
+          <Button size="sm" variant="outline">
+            <UserPlus />
+            Add Student
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <div className="xl:col-span-12">
+          <KpiCards />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/academy/page.tsx
+++ b/src/app/(main)/dashboard/academy/page.tsx
@@ -1,9 +1,12 @@
-import { BarChart3, Plus, UserPlus } from "lucide-react";
+import { BookOpenCheck, Megaphone, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 
+import { AssignmentStatus } from "./_components/assignment-status";
 import { ClassSchedule } from "./_components/class-schedule";
 import { KpiCards } from "./_components/kpi-cards";
+import { PerformanceHighlights } from "./_components/performance-highlights";
+import { UpcomingEvents } from "./_components/upcoming-events";
 
 export default function Page() {
   return (
@@ -12,22 +15,22 @@ export default function Page() {
         <div className="space-y-1">
           <h1 className="text-3xl tracking-tight">Academy Dashboard</h1>
           <p className="text-muted-foreground text-sm">
-            Good morning, Admin. Here's a quick overview of today's activity.
+            Good morning, Teacher. Here's a quick overview of today's activity.
           </p>
         </div>
 
         <div className="flex flex-wrap items-center gap-2 lg:w-fit">
           <Button size="sm">
-            <Plus />
+            <Megaphone />
             New Announcement
           </Button>
           <Button size="sm" variant="outline">
-            <BarChart3 />
-            View Results
+            <BookOpenCheck />
+            Gradebook
           </Button>
           <Button size="sm" variant="outline">
-            <UserPlus />
-            Add Student
+            <Plus />
+            Add Assignment
           </Button>
         </div>
       </div>
@@ -37,6 +40,18 @@ export default function Page() {
       <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
         <div className="xl:col-span-5">
           <ClassSchedule />
+        </div>
+        <div className="xl:col-span-7">
+          <AssignmentStatus />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-12">
+        <div className="xl:col-span-8">
+          <PerformanceHighlights />
+        </div>
+        <div className="xl:col-span-4">
+          <UpcomingEvents />
         </div>
       </div>
     </div>

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -81,9 +81,9 @@ export const sidebarItems: NavGroup[] = [
       },
       {
         title: "Academy",
-        url: "/dashboard/coming-soon",
+        url: "/dashboard/academy",
         icon: GraduationCap,
-        comingSoon: true,
+        isNew: true,
       },
       {
         title: "Logistics",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a new Academy dashboard page with five sub-components: KPI cards, a class schedule list, an assignment status bar chart, a custom Gantt-style performance highlights chart, and an upcoming events panel. The sidebar navigation entry for Academy is updated from `comingSoon` to `isNew` and pointed at the new route.

- **KPI cards & assignment chart** (`kpi-cards.tsx`, `assignment-status.tsx`): All four KPI values are internally consistent with the chart data (63 pending + 18 overdue = 81 total; 5 classes with matching statuses). The dot-pattern SVG fills in the bar chart are wired correctly through the `ChartContainer` CSS custom properties.
- **Performance highlights** (`performance-highlights.tsx`): Uses a stacked transparent-bar trick to create a Gantt-style horizontal bar chart with embedded avatars and a score fill. The `fillWidth` minimum of 86 px can cause the fill rect to overflow the background rect on narrow containers.
- **Date-dependent server components** (`class-schedule.tsx`, `upcoming-events.tsx`): Both call `new Date()` in server components without any dynamic-rendering opt-in, so their date output may be frozen at build time in a statically cached deployment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive UI components with hardcoded demo data and no backend interactions.

The PR adds a self-contained dashboard page with no dynamic data fetching, authentication changes, or shared state mutations. The two observations (date freshness in server components and fill-bar overflow edge case) are minor visual issues confined to a demo context and do not affect any existing functionality.

`upcoming-events.tsx` and `class-schedule.tsx` — both render dates computed from `new Date()` in server components without a dynamic-rendering opt-in, which could produce stale dates if the page is statically cached.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/(main)/dashboard/academy/page.tsx | New Academy dashboard page composing all five sub-components into a two-row grid layout; no dynamic data fetching, no `export const dynamic` opt-in. |
| src/app/(main)/dashboard/academy/_components/upcoming-events.tsx | Server component that computes event dates via `new Date()` at render time; may produce stale/build-time dates in statically cached deployments. |
| src/app/(main)/dashboard/academy/_components/class-schedule.tsx | Server component using `new Date()` for schedule date labels; same static-caching risk as `upcoming-events.tsx`. |
| src/app/(main)/dashboard/academy/_components/performance-highlights.tsx | Custom SVG bar chart with a Gantt-style layout; `fillWidth` minimum of 86 px can overflow the background rect on narrow viewports. |
| src/app/(main)/dashboard/academy/_components/assignment-status.tsx | Grouped bar chart with custom dot-pattern SVG fills; well-structured and consistent with project chart conventions. |
| src/app/(main)/dashboard/academy/_components/kpi-cards.tsx | Four static KPI cards with consistent dark-mode badge styling; values are self-consistent across components. |
| src/navigation/sidebar/sidebar-items.ts | Promotes Academy sidebar entry from `comingSoon: true` to `isNew: true` and updates the URL to `/dashboard/academy`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["page.tsx\n/dashboard/academy"] --> B["KpiCards\n(server)"]
    A --> C["ClassSchedule\n(server)"]
    A --> D["AssignmentStatus\n(client)"]
    A --> E["PerformanceHighlights\n(client)"]
    A --> F["UpcomingEvents\n(server)"]

    C -->|"new Date()"| G["⚠️ May be build-time\nin static deployments"]
    F -->|"new Date()"| G

    D --> H["Recharts BarChart\n+ SVG dot patterns"]
    E --> I["Recharts BarChart\n+ custom SVG shape\nPerformanceHighlightBar"]
    I --> J["⚠️ fillWidth min 86px\nmay overflow on narrow\nviewports"]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/app/(main)/dashboard/academy/_components/upcoming-events.tsx:41
**`new Date()` in a server component may freeze at build time**

Both `UpcomingEvents` and `ClassSchedule` call `new Date()` in server components, and neither the page nor any ancestor calls `cookies()`, `headers()`, or any other function that forces dynamic rendering. In a Next.js App Router project that doesn't explicitly opt into dynamic rendering (`export const dynamic = 'force-dynamic'`), the output may be statically cached — meaning every user would see the build-time date, not today's date. For `UpcomingEvents`, this is critical: all event calendar tiles would show dates offset from the build timestamp rather than the current day. Adding `export const dynamic = 'force-dynamic'` to `page.tsx`, or converting `UpcomingEvents`/`ClassSchedule` to Client Components with `new Date()` called on mount, would ensure the dates stay accurate. The same issue affects `class-schedule.tsx` line 8.

### Issue 2 of 2
src/app/(main)/dashboard/academy/_components/performance-highlights.tsx:74
**Fill rect can overflow the background rect when `width` is small**

`fillWidth = Math.max(width * (payload.score / 100), 86)` enforces a minimum of 86 px so the avatar + label cluster always fits, but when `width < 86` (narrow viewport or small container) `fillWidth` will exceed `width`. The filled `<rect>` at line 90 would then render wider than the background `<rect>`, visually overflowing it and potentially covering the score text anchored at `x + width - 10` (line 118). A safer fallback is to clamp `fillWidth` to at most `width`: `Math.min(Math.max(width * (payload.score / 100), 86), width)`.

`````

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: updates"](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/e6545ace19248b1533740f324706a6b8e9b5867b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31597583)</sub>

<!-- /greptile_comment -->