### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ You can run this project locally, or deploy it instantly with Vercel.
 ### Deploy with Vercel
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Farhamkhnz%2Fnext-shadcn-admin-dashboard)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=arhamkhnz/next-shadcn-admin-dashboard&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 _Deploy your own copy with one click._
 


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=arhamkhnz/next-shadcn-admin-dashboard)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a one-line "Deploy to PandaStack" badge to `README.md` alongside the existing Vercel button. The badge URL contains build parameters that do not match the project's actual Next.js setup, which would cause the deploy flow to fail or produce a broken site for anyone who clicks it.

- `type=static` is specified, but this project is a Next.js SSR application with server-side `redirects()` configured and no `output: 'export'` in `next.config.mjs` — a static deployment cannot serve it correctly.
- `outputDir=dist` does not exist in this project; `next build` writes its output to `.next`, so PandaStack would look for an artifact directory that is never produced.

<h3>Confidence Score: 3/5</h3>

The change is documentation-only but the deploy URL it introduces points to a misconfigured build that would fail or produce a broken deployment for every user who clicks it.

The deploy button hard-codes `type=static` and `outputDir=dist`, neither of which matches this Next.js project. The project has server-side redirects and no static-export configuration, so anyone clicking the button would get a failed or broken deployment. The fix is confined to the URL query string in one line of README.md.

README.md — the PandaStack deploy URL needs corrected `type`, `outputDir`, and a `startCmd` before the button is useful.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a PandaStack deploy button with incorrect build parameters — `type=static` and `outputDir=dist` do not match this Next.js SSR project's actual output configuration. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant README as README.md
    participant PandaStack as dashboard.pandastack.io
    participant Repo as GitHub Repo

    User->>README: Clicks "Deploy to PandaStack" button
    README->>PandaStack: "GET /deploy?type=static&buildCmd=npm+run+build&outputDir=dist"
    PandaStack->>Repo: Clone repository
    PandaStack->>PandaStack: Run npm run build (outputs to .next, not dist)
    PandaStack->>PandaStack: Look for output in dist/ (does not exist)
    PandaStack-->>User: Deployment fails or serves broken site
    Note over PandaStack,User: type=static skips Node.js server needed for redirects()
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:91
The deploy URL parameters `type=static` and `outputDir=dist` are both incorrect for this project. `next.config.mjs` has no `output: 'export'` setting and defines server-side `redirects()`, so this is an SSR app — not a static site. `next build` writes to `.next`, not `dist`. Deploying with these parameters will either fail at the artifact-collection step (missing `dist/`) or produce a broken deployment that cannot serve server-side routes or redirects.

```suggestion
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=arhamkhnz/next-shadcn-admin-dashboard&type=node&buildCmd=npm+run+build&startCmd=npm+run+start&outputDir=.next)
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Deploy to PandaStack button"](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/f1d5a2fced9d50112ca6920e7268387bdbe71b78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31768071)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->