### PR TITLE
refactor: use simplified Tailwind has variant syntax

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground has-[[role=checkbox]]:pr-0",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        "p-2 align-middle whitespace-nowrap has-[[role=checkbox]]:pr-0",
         className
       )}
       {...props}


### PR DESCRIPTION
This PR replaces the legacy has() selector syntax with the simplified Tailwind v4 has variant syntax.

No visual or behavioral changes were made.

The update only improves readability and consistency with modern Tailwind conventions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR modernizes equivalent Tailwind `:has()` variant syntax in the shared table component without changing selector behavior.

- Replaces arbitrary `&:has(...)` variants in `TableHead` and `TableCell`.
- Preserves conditional right-padding removal for cells containing checkboxes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable behavioral, visual, or build issues identified.

The replacement syntax is supported by the repository’s Tailwind v4 toolchain and preserves the existing descendant-checkbox selector behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/ui/table.tsx | Both table padding selectors were converted to supported Tailwind v4 shorthand with equivalent behavior. |

<sub>Reviews (1): Last reviewed commit: ["refactor: use simplified Tailwind has va..."](https://github.com/arhamkhnz/next-shadcn-admin-dashboard/commit/f7cd926153ce8d2cb7fa8167247eed990c4abb57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53786953)</sub>

**Context used:**

- Knowledge Base — [UI Component Library](https://app.greptile.com/weblabs-studio/-/custom-context/knowledge-base/arhamkhnz/next-shadcn-admin-dashboard/-/docs/ui-component-library.md)

<!-- /greptile_comment -->